### PR TITLE
Add auditing support for "special" QuerySet write methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Django Field Audit change log
 
+## v1.1.0 - 2022-07-22
+
+- Add Django compatibility tests.
+- Add auditing support for "special" `QuerySet` write methods
+
 ## v1.0.0 - 2022-05-31
 
 - Remove `FieldChange` model in favor of storing the full delta on the

--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ class Aircraft(models.Model):
     operated_by = models.CharField(max_length=64)
 ```
 
+#### Audited DB write operations
+
+| DB Write Method               | Audited
+|:------------------------------|:-------
+| `Model.delete()`              | Yes
+| `Model.save()`                | Yes
+| `QuerySet.bulk_create()`      | No
+| `QuerySet.bulk_update()`      | No
+| `QuerySet.create()`           | Yes (via `Model.save()`)
+| `QuerySet.delete()`           | No
+| `QuerySet.get_or_create()`    | Yes (via `QuerySet.create()`)
+| `QuerySet.update()`           | No
+| `QuerySet.update_or_create()` | Yes (via `QuerySet.get_or_create()` and `Model.save()`)
+
 ### Using with SQLite
 
 This app uses Django's `JSONField` which means if you intend to use the app with
@@ -154,10 +168,13 @@ twine upload dist/*
 ## TODO
 
 - Write backfill migration utility / management command.
-- Add support for `QuerySet` write operations (`update()`, etc).
+- Add support for remaining `QuerySet` write operations:
+  - `bulk_create()`
+  - `bulk_update()`
+  - `delete()`
+  - `update()`
 - Write full library documentation using github.io.
 - Switch to `pytest` to support Python 3.10.
-- Write `test_library.py` functional test module for entire library.
 
 ### Backlog
 

--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,3 +1,3 @@
 from .field_audit import audit_fields  # noqa: F401
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -27,6 +27,15 @@ def audit_fields(*field_names, class_path=None):
     :param class_path: optional name to use as the ``object_class_path`` field
         on audit events. The default (``None``) means the audited model's
         fully qualified "dot path" will be used.
+
+    Auditing is performed by decorating the model class's ``__init__()``,
+    ``delete()`` and ``save()`` methods which provides audit events for all DB
+    write operations except:
+
+    - ``QuerySet.bulk_create()``
+    - ``QuerySet.bulk_update()``
+    - ``QuerySet.update()``
+    - ``QuerySet.delete()``
     """
     def wrapper(cls):
         if cls in _audited_models:

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -15,10 +15,14 @@ __all__ = [
 
 
 class AlreadyAudited(Exception):
-    """Class is already audited."""
+    """Model class is already audited."""
 
 
-def audit_fields(*field_names, class_path=None):
+class InvalidManagerError(Exception):
+    """Model class has an invalid manager."""
+
+
+def audit_fields(*field_names, class_path=None, audit_special_queryset_writes=False):  # noqa: E501
     """Class decorator for auditing field changes on DB model instances.
 
     Use this on Model subclasses which need field change auditing.
@@ -27,15 +31,25 @@ def audit_fields(*field_names, class_path=None):
     :param class_path: optional name to use as the ``object_class_path`` field
         on audit events. The default (``None``) means the audited model's
         fully qualified "dot path" will be used.
+    :param audit_special_queryset_writes: optional bool (default ``False``)
+        enables auditing of the "special" QuerySet write methods (see below) for
+        this model. Setting this to ``True`` requires the decorated model's
+        default manager be an instance of ``field_audit.models.AuditingManager``
+        **IMPORTANT**: These special QuerySet write methods often perform bulk
+        or batched operations, and auditing their changes may impact efficiency.
+    :raises: ``ValueError``, ``InvalidManagerError``
 
     Auditing is performed by decorating the model class's ``__init__()``,
     ``delete()`` and ``save()`` methods which provides audit events for all DB
-    write operations except:
+    write operations except the "special" QuerySet write methods:
 
     - ``QuerySet.bulk_create()``
     - ``QuerySet.bulk_update()``
     - ``QuerySet.update()``
     - ``QuerySet.delete()``
+
+    Using ``audit_special_queryset_writes=True`` (with the custom manager) lifts
+    this limitation.
     """
     def wrapper(cls):
         if cls in _audited_models:
@@ -43,6 +57,8 @@ def audit_fields(*field_names, class_path=None):
         if not issubclass(cls, models.Model):
             raise ValueError(f"expected Model subclass, got: {cls}")
         AuditEvent.attach_field_names(cls, field_names)
+        if audit_special_queryset_writes:
+            _verify_auditing_manager(cls)
         cls.__init__ = _decorate_init(cls.__init__)
         cls.save = _decorate_db_write(cls.save)
         cls.delete = _decorate_db_write(cls.delete)
@@ -52,6 +68,23 @@ def audit_fields(*field_names, class_path=None):
         raise ValueError("at least one field name is required")
     from .models import AuditEvent
     return wrapper
+
+
+def _verify_auditing_manager(cls):
+    """Verifies a model class is configured with an appropriate manager for
+    special QuerySet write auditing.
+
+    :param cls: a Model subclass
+    :raises: ``InvalidManagerError``
+    """
+    from .models import AuditingManager
+    # Don't assume 'cls.objects', use 'cls._default_manager' instead.
+    # see: https://docs.djangoproject.com/en/4.0/topics/db/managers/#default-managers  # noqa: E501
+    if not isinstance(cls._default_manager, AuditingManager):
+        raise InvalidManagerError(
+            "QuerySet write auditing requires an AuditingManager, got "
+            f"{type(cls._default_manager)}"
+        )
 
 
 def _decorate_init(init):

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,12 @@ from django.db.models import (
 from field_audit import audit_fields
 
 
+@audit_fields("id", "value")
+class SimpleModel(Model):
+    id = AutoField(primary_key=True)
+    value = CharField(max_length=8, null=True)
+
+
 @audit_fields("name", "title", "flight_hours")
 class CrewMember(Model):
     id = AutoField(primary_key=True)

--- a/tests/models.py
+++ b/tests/models.py
@@ -12,12 +12,20 @@ from django.db.models import (
 )
 
 from field_audit import audit_fields
+from field_audit.models import AuditingManager
 
 
 @audit_fields("id", "value")
 class SimpleModel(Model):
     id = AutoField(primary_key=True)
     value = CharField(max_length=8, null=True)
+
+
+@audit_fields("id", "value", audit_special_queryset_writes=True)
+class ModelWithAuditingManager(Model):
+    id = AutoField(primary_key=True)
+    value = CharField(max_length=8, null=True)
+    objects = AuditingManager()
 
 
 @audit_fields("name", "title", "flight_hours")

--- a/tests/test_django_compat.py
+++ b/tests/test_django_compat.py
@@ -1,0 +1,115 @@
+
+from django.test import TestCase
+
+from field_audit.models import AuditEvent
+
+from .models import SimpleModel
+
+
+class TestAuditedDbWrites(TestCase):
+
+    def test_model_delete_is_audited(self):
+        self.assertNoAuditEvents()
+        instance = SimpleModel.objects.create()
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        instance.delete()
+        self.assertAuditEvent(
+            is_delete=True,
+            delta={"id": {"old": instance.id}, "value": {"old": None}},
+        )
+
+    def test_model_save_is_audited(self):
+        self.assertNoAuditEvents()
+        SimpleModel(id=0).save()
+        self.assertAuditEvent(
+            is_create=True,
+            delta={"id": {"new": 0}, "value": {"new": None}},
+        )
+
+    def test_queryset_bulk_create_is_not_audited(self):
+        self.assertNoAuditEvents()
+        instance, = SimpleModel.objects.bulk_create([SimpleModel()])
+        instance.refresh_from_db()
+        self.assertIsNotNone(instance.id)
+        self.assertNoAuditEvents()
+
+    def test_queryset_bulk_update_is_not_audited(self):
+        instance = SimpleModel.objects.create()
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        self.assertIsNone(instance.value)
+        instance.value = "test"
+        updates = SimpleModel.objects.bulk_update([instance], ["value"])
+        self.assertEqual(1, updates)
+        instance.refresh_from_db()
+        self.assertEqual("test", instance.value)
+        self.assertNoAuditEvents()
+
+    def test_queryset_create_is_audited(self):
+        self.assertNoAuditEvents()
+        instance = SimpleModel.objects.create()
+        self.assertAuditEvent(
+            is_create=True,
+            delta={"id": {"new": instance.id}, "value": {"new": None}},
+        )
+
+    def test_queryset_delete_is_not_audited(self):
+        self.assertNoAuditEvents()
+        instance = SimpleModel.objects.create()
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        instance.refresh_from_db()
+        self.assertIsNotNone(instance.id)
+        SimpleModel.objects.all().delete()
+        self.assertNoAuditEvents()
+
+    def test_queryset_get_or_create_is_audited(self):
+        self.assertNoAuditEvents()
+        self.assertEqual([], list(SimpleModel.objects.all()))
+        SimpleModel.objects.get_or_create(id=0)
+        self.assertAuditEvent(
+            is_create=True,
+            delta={"id": {"new": 0}, "value": {"new": None}},
+        )
+
+    def test_queryset_update_is_not_audited(self):
+        self.assertNoAuditEvents()
+        instance = SimpleModel.objects.create()
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        SimpleModel.objects.all().update(value="test")
+        instance.refresh_from_db()
+        self.assertEqual("test", instance.value)
+        self.assertNoAuditEvents()
+
+    def test_queryset_update_or_create_is_audited_on_create(self):
+        self.assertNoAuditEvents()
+        self.assertEqual([], list(SimpleModel.objects.all()))
+        response = SimpleModel.objects.update_or_create({"value": "test"}, id=0)
+        instance, x = response
+        self.assertEqual(0, instance.id)
+        self.assertEqual("test", instance.value)
+        self.assertAuditEvent(
+            is_create=True,
+            delta={"id": {"new": 0}, "value": {"new": "test"}},
+        )
+
+    def test_queryset_update_or_create_is_audited_on_update(self):
+        self.assertNoAuditEvents()
+        instance = SimpleModel.objects.create()
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        self.assertEqual([instance], list(SimpleModel.objects.all()))
+        self.assertIsNone(instance.value)
+        SimpleModel.objects.update_or_create({"value": "test"}, id=instance.id)
+        instance.refresh_from_db()
+        self.assertEqual("test", instance.value)
+        self.assertAuditEvent(
+            is_create=False,
+            is_delete=False,
+            delta={"value": {"old": None, "new": "test"}},
+        )
+
+    def assertNoAuditEvents(self):
+        self.assertEqual([], list(AuditEvent.objects.all()))
+
+    def assertAuditEvent(self, **kwargs):
+        event, = AuditEvent.objects.all()
+        for name, value in kwargs.items():
+            self.assertEqual(value, getattr(event, name))

--- a/tests/test_field_audit.py
+++ b/tests/test_field_audit.py
@@ -7,14 +7,16 @@ from django.test import TestCase
 
 from field_audit.field_audit import (
     AlreadyAudited,
+    InvalidManagerError,
     _audited_models,
+    _verify_auditing_manager,
     _decorate_db_write,
     audit_fields,
     get_audited_class_path,
     get_audited_models,
     request as audit_request,
 )
-from field_audit.models import AuditEvent
+from field_audit.models import AuditEvent, AuditingManager
 
 from .models import (
     Aerodrome,
@@ -22,6 +24,7 @@ from .models import (
     CrewMember,
     Flight,
     SimpleModel,
+    ModelWithAuditingManager,
 )
 
 
@@ -46,6 +49,12 @@ class TestFieldAudit(TestCase):
             @audit_fields("field")
             class Test:
                 pass
+
+    def test__verify_auditing_manager_with_incorrect_manager_raises(self):
+        class Item0(models.Model):
+            pass
+        with self.assertRaises(InvalidManagerError):
+            _verify_auditing_manager(Item0)
 
     def test__decorate_db_write_for_invalid_func_raises(self):
         def invalid(self):
@@ -88,9 +97,33 @@ class TestFieldAudit(TestCase):
                 item.unsupported()
                 classmeth.assert_not_called()
 
+    def test_audit_fields_verifies_manager_for_audit_special_queryset_writes(self):  # noqa: E501
+
+        class Item1(models.Model):
+            value = models.IntegerField()
+
+        class Item2(models.Model):
+            value = models.IntegerField()
+            objects = AuditingManager()
+
+        with override_audited_models():
+            audit_fields("value")(Item1)  # doesn't raise
+        with self.assertRaises(InvalidManagerError):
+            audit_fields("value", audit_special_queryset_writes=True)(Item1)
+        with override_audited_models():
+            # doesn't raise
+            audit_fields("value", audit_special_queryset_writes=True)(Item2)
+
     def test_get_audited_models(self):
         self.assertEqual(
-            {Aerodrome, Aircraft, CrewMember, Flight, SimpleModel},
+            {
+                Aerodrome,
+                Aircraft,
+                CrewMember,
+                Flight,
+                SimpleModel,
+                ModelWithAuditingManager,
+            },
             set(get_audited_models()),
         )
 

--- a/tests/test_field_audit.py
+++ b/tests/test_field_audit.py
@@ -51,7 +51,7 @@ class TestFieldAudit(TestCase):
         def invalid(self):
             pass
         with self.assertRaises(ValueError):
-            invalid = _decorate_db_write(invalid, ["field"])
+            _decorate_db_write(invalid)
 
     def test_audit_fields_adds_audited_models(self):
         with override_audited_models():

--- a/tests/test_field_audit.py
+++ b/tests/test_field_audit.py
@@ -21,6 +21,7 @@ from .models import (
     Aircraft,
     CrewMember,
     Flight,
+    SimpleModel,
 )
 
 
@@ -89,7 +90,7 @@ class TestFieldAudit(TestCase):
 
     def test_get_audited_models(self):
         self.assertEqual(
-            {Aerodrome, Aircraft, CrewMember, Flight},
+            {Aerodrome, Aircraft, CrewMember, Flight, SimpleModel},
             set(get_audited_models()),
         )
 


### PR DESCRIPTION
As discussed in [this comment](https://github.com/dimagi/django-field-audit/pull/1#discussion_r882193539) on PR #1, auditing of QuerySet write methods is now supported[^1].

Documentation provided in change set. Particularly:
- [README.md: Audited DB write operations](https://github.com/dimagi/django-field-audit/blob/queryset/README.md#audited-db-write-operations)
- [AuditingQuerySet docstring](https://github.com/dimagi/django-field-audit/blob/queryset/field_audit/models.py#L337-L361)

Changes:

- Adds Django compatibility tests.
- Adds auditing support for "special" `QuerySet` write methods
- Bumps version to `1.1.0`

Recommended review commit by commit :tropical_fish: 

[^1]: Specificaly at the capacity needed for HQ `UserRole` auditing. That is, only `QuerySet.delete()` auditing is supported at this time, although passthrough (ignore) is supported for all "special" write methods on the new manager. See README for more details.