### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ class Aircraft(models.Model):
 This app uses Django's `JSONField` which means if you intend to use the app with
 a SQLite database, the SQLite `JSON1` extension is required. If your system's
 Python `sqlite3` library doesn't ship with this extension enabled, see
-[this article]((https://code.djangoproject.com/wiki/JSON1Extension)) for details
+[this article](https://code.djangoproject.com/wiki/JSON1Extension) for details
 on how to enable it.
 
 


### PR DESCRIPTION
As shown in the screenshot, the sentence that should look like
> ...see [this article](https://code.djangoproject.com/wiki/JSON1Extension) for details...

does not hyperlink correctly. Removing the additional parenthesis  resolves this issue.

<img width="1019" alt="Screen Shot 2022-08-01 at 8 13 04 PM" src="https://user-images.githubusercontent.com/15785053/182284016-44f4b03a-b876-4816-92ff-f0368ac44e32.png">
