### PR TITLE
Fix migration constraint condition ordering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,8 +66,8 @@ jobs:
       run: |
         ./example/manage.py makemigrations field_audit
         git add ./field_audit/migrations
+        trap 'git reset --hard HEAD' EXIT  # discard changes on exit (needed for continue-on-error)
         git diff --cached --exit-code
-        git reset --hard HEAD  # discard changes (needed for continue-on-error)
       continue-on-error: ${{ matrix.experimental }}
     - name: Check style
       run: flake8 --config=setup.cfg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,9 @@ jobs:
     - name: Check migrations
       run: |
         ./example/manage.py makemigrations field_audit
-        git add --all
+        git add ./field_audit/migrations
         git diff --cached --exit-code
+        git reset --hard HEAD  # discard changes (needed for continue-on-error)
+      continue-on-error: ${{ matrix.experimental }}
     - name: Check style
       run: flake8 --config=setup.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Django Field Audit change log
 
+## v1.2.1 - 2022-08-12
+
+- Fix migration constraint condition ordering which caused Django<4.0 to think
+  a new migration was needed.
+
 ## v1.2.0 - 2022-08-05
 
 - Add ability to bootstrap audit events for existing model records.

--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,3 +1,3 @@
 from .field_audit import audit_fields  # noqa: F401
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/field_audit/migrations/0002_add_is_bootstrap_column.py
+++ b/field_audit/migrations/0002_add_is_bootstrap_column.py
@@ -20,8 +20,8 @@ class Migration(migrations.Migration):
                 check=models.Q(
                     models.Q(
                         models.Q(('is_create', True), ('is_delete', True)),
-                        models.Q(('is_create', True), ('is_bootstrap', True)),
-                        models.Q(('is_delete', True), ('is_bootstrap', True)),
+                        models.Q(('is_bootstrap', True), ('is_create', True)),
+                        models.Q(('is_bootstrap', True), ('is_delete', True)),
                         _connector='OR',
                     ),
                     _negated=True,


### PR DESCRIPTION
Leave constraint conditions in Django-created order

Previous conditions had been manually rearranged for readability, which was fine for Django>=4.0. Unfortunately this caused Django<4.0 to think that a new migration was required.