### PR TITLE
Use batching by default for bootstrap operations

### DIFF
--- a/.github/workflows/verify-changelog.yml
+++ b/.github/workflows/verify-changelog.yml
@@ -1,0 +1,14 @@
+name: verify-changelog
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Verify changelog version
+      run: ./scripts/verify-changelog-version.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Django Field Audit change log
 
+## v1.2.3 - 2022-09-02
+
+- Use batching by default for all bootstrap operations
+- Add a `--batch-size` option to the bootstrap management command
+
 ## v1.2.2 - 2022-08-19
 
 - Add management command for bootstrapping

--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,3 +1,3 @@
 from .field_audit import audit_fields  # noqa: F401
 
-__version__ = "1.2.2"
+__version__ = "1.2.3"

--- a/field_audit/const.py
+++ b/field_audit/const.py
@@ -1,0 +1,19 @@
+
+# Number of records to bulk fetch/insert per batch for bootstrap operations.
+#
+# Benchmark testing of this value was performed by bootstrapping a table with
+# five (5) columns and ~2.6 million rows. Two benchmark runs were performed with
+# the database reset and restarted between runs. The first benchmark used
+# 'batch_size=1000' and completed in 6min 15sec, the second benchmark used
+# 'batch_size=10000' and completed in 6min 12sec (less than 1% difference in
+# runtime). There was no noticeable difference in database resource usage
+# between the two runs, but the Django process consistently used about 160MiB
+# more memory for the duration of the second benchmark compared to the first.
+# Given that the overall runtime was relatively unaffected between two tests
+# whose batch size differed by an order of magnitude, the lower value seems like
+# the better default due to the lower Django resource usage.
+#
+# Installations with noticeable database connection latency may prefer to
+# specify a higher value on their bootstrap operations in order to optimize for
+# fewer round-trips to the database.
+BOOTSTRAP_BATCH_SIZE = 1000

--- a/field_audit/utils.py
+++ b/field_audit/utils.py
@@ -70,7 +70,7 @@ def run_bootstrap(model_class, field_names, batch_size=None, iter_records=None,
         unapplying the migration. Passed directly to the returned
         ``RunPython()`` instance as the ``reverse_code`` argument.
     """
-    def wrapper(*args, **kwargs):
+    def do_bootstrap(*args, **kwargs):
         from .models import AuditEvent
         count = AuditEvent.bootstrap_existing_model_records(
             model_class,
@@ -78,5 +78,8 @@ def run_bootstrap(model_class, field_names, batch_size=None, iter_records=None,
             batch_size,
             iter_records,
         )
-        log.info(f"boostrapped {count} audit event(s) for model: {model_class}")
-    return RunPython(wrapper, reverse_code=reverse_func)
+        log.info(
+            f"bootstrapped {count} audit event{'' if count == 1 else 's'} for: "
+            f"{model_class._meta.app_label}.{model_class._meta.object_name}"
+        )
+    return RunPython(do_bootstrap, reverse_code=reverse_func)

--- a/field_audit/utils.py
+++ b/field_audit/utils.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.migrations import RunPython
 from django.utils.module_loading import import_string
 
+from .const import BOOTSTRAP_BATCH_SIZE
+
 log = logging.getLogger(__name__)
 
 
@@ -52,8 +54,8 @@ def get_fqcn(cls):
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
-def run_bootstrap(model_class, field_names, batch_size=None, iter_records=None,
-                  reverse_func=RunPython.noop):
+def run_bootstrap(model_class, field_names, batch_size=BOOTSTRAP_BATCH_SIZE,
+                  iter_records=None, reverse_func=RunPython.noop):
     """Returns a django migration Operation which calls
     ``AuditEvent.bootstrap_existing_model_records()`` to add "migration" records
     for existing model records.
@@ -63,7 +65,8 @@ def run_bootstrap(model_class, field_names, batch_size=None, iter_records=None,
     :param field_names: see
         ``field_audit.models.AuditEvent.bootstrap_existing_model_records``
     :param batch_size: see
-        ``field_audit.models.AuditEvent.bootstrap_existing_model_records``
+        ``field_audit.models.AuditEvent.bootstrap_existing_model_records``,
+        (default=field_audit.const.BOOTSTRAP_BATCH_SIZE)
     :param iter_records:  see
         ``field_audit.models.AuditEvent.bootstrap_existing_model_records``
     :param reverse_func: (optional, default: ``RunPython.noop``) a callable for

--- a/scripts/verify-changelog-version.py
+++ b/scripts/verify-changelog-version.py
@@ -22,9 +22,7 @@ def get_lib_version(filepath):
 def get_latest_changelog_version(filepath):
     expected_msg = "(expected format: '## vN.N.N - <date>')"
     with open(filepath, "r") as file:
-        line_num = 0
-        for line in file:
-            line_num += 1
+        for line_num, line in enumerate(file, start=1):
             if line.startswith("##"):
                 # the first non-H1 header must be the latest version
                 try:

--- a/scripts/verify-changelog-version.py
+++ b/scripts/verify-changelog-version.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import re
+import sys
+
+
+def main():
+    lib_version = get_lib_version("./field_audit/__init__.py")
+    chlog_version = get_latest_changelog_version("./CHANGELOG.md")
+    if lib_version != chlog_version:
+        raise Fail(
+            "Library and latest changelog versions do not match: "
+            f"{lib_version!r} != {chlog_version!r}"
+        )
+    print(f"Library and latest changelog versions match: {lib_version}")
+
+
+def get_lib_version(filepath):
+    with open(filepath, "r") as file:
+        return re.search(r'__version__ = "([^"]+)"', file.read()).group(1)
+
+
+def get_latest_changelog_version(filepath):
+    expected_msg = "(expected format: '## vN.N.N - <date>')"
+    with open(filepath, "r") as file:
+        line_num = 0
+        for line in file:
+            line_num += 1
+            if line.startswith("##"):
+                # the first non-H1 header must be the latest version
+                try:
+                    # second field, drop the leading "v"
+                    version_string = line.split()[1][1:]
+                except IndexError:
+                    version_string = None
+                if not version_string:
+                    raise InvalidChangelog(
+                        f"Invalid changelog header on line {line_num}: "
+                        f"{line!r} {expected_msg}"
+                    )
+                return version_string
+    raise InvalidChangelog(f"No changlog entries found {expected_msg}")
+
+
+class Fail(Exception):
+    pass
+
+
+class InvalidChangelog(Fail):
+    pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Fail as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_bootstrap_field_audit_events.py
+++ b/tests/test_bootstrap_field_audit_events.py
@@ -1,12 +1,12 @@
 from contextlib import contextmanager
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 from django.core.management import CommandError, call_command
 from django.db import models
 from django.test import TestCase
 
-
+from field_audit.const import BOOTSTRAP_BATCH_SIZE
 from field_audit.field_audit import get_audited_models
 from field_audit.management.commands import (
     bootstrap_field_audit_events as bootstrap,
@@ -78,6 +78,27 @@ class TestCommand(TestCase):
                 self.assertRaises(bootstrap.InvalidModelState),
             ):
                 bootstrap.Command.setup_models()
+
+    def test_bootstrap_uses_default_batch_size(self):
+        with patch.object(AuditEvent, "bootstrap_top_up") as mock:
+            self.quiet_command("top-up", "PkAuto")
+            mock.assert_called_once_with(
+                PkAuto, ANY, batch_size=BOOTSTRAP_BATCH_SIZE,
+            )
+
+    def test_bootstrap_allows_custom_batch_size(self):
+        with patch.object(AuditEvent, "bootstrap_top_up") as mock:
+            self.quiet_command("top-up", "--batch-size", "1", "PkAuto")
+            mock.assert_called_once_with(PkAuto, ANY, batch_size=1)
+
+    def test_bootstrap_disables_batching_for_batch_size_zero(self):
+        with patch.object(AuditEvent, "bootstrap_top_up") as mock:
+            self.quiet_command("top-up", "--batch-size", "0", "PkAuto")
+            mock.assert_called_once_with(PkAuto, ANY, batch_size=None)
+
+    def test_bootstrap_crashes_for_negative_batch_size(self):
+        with self.assertRaises(CommandError):
+            self.quiet_command("top-up", "--batch-size", "-1", "PkAuto")
 
     def test_bootstrap_crashes_early_if_model_has_invalid_fields(self):
         with (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db.migrations.operations import RunPython
 from django.test import SimpleTestCase
 
+from field_audit.const import BOOTSTRAP_BATCH_SIZE
 from field_audit.utils import (
     class_import_helper,
     get_fqcn,
@@ -71,11 +72,12 @@ class TestRunBootstrapExistingModel(SimpleTestCase):
     def test_run_bootstrap(self):
         def reverse():
             return None
-        bootstrap_args = (Flight, ["field"], None, None)
-        migration_op = run_bootstrap(*bootstrap_args, reverse_func=reverse)
+        run_bs_args = (Flight, ["field"])
+        run_bs_def_args = (BOOTSTRAP_BATCH_SIZE, None)
+        migration_op = run_bootstrap(*run_bs_args, reverse_func=reverse)
         self.assertIsInstance(migration_op, RunPython)
         self.assertIs(reverse, migration_op.reverse_code)
         path = "field_audit.models.AuditEvent.bootstrap_existing_model_records"
         with patch(path) as do_bootstrap:
             migration_op.code()
-            do_bootstrap.assert_called_once_with(*bootstrap_args)
+            do_bootstrap.assert_called_once_with(*run_bs_args, *run_bs_def_args)


### PR DESCRIPTION
Use batching by default for bootstrap operations.

Accidentally running the built-in bootstrapping helper utilities (migration operation and/or management command) on large datasets without setting a `batch_size` can result in extremely poor system performance (very high memory usage by both Django and the database backend due to _very_ large query processing).  Batching is now enabled by default with a reasonable default value. The batching behavior can always be explicitly configured (disabled or size changed) for any bootstrapping operation in the event downstream projects need to change this behavior for specific use-cases.

Changes:
- Use batching by default for all bootstrap operations
- Add a `--batch-size` option to the bootstrap management command