### PR TITLE
Add audit support for AuditingQuerySet.update()

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,13 @@ details:
 - Specifying `audit_special_queryset_writes=True` (step **1** above) without
   setting the default manager to an instance of `AuditingManager` (step **2**
   above) will raise an exception when the model class is evaluated.
-- At this time, only the `QuerySet.delete()` "special" write method can actually
-  perform change auditing when called with `audit_action=AuditAction.AUDIT`. The
-  other three methods are currently not implemented and will raise
-  `NotImplementedError` if called with that action. Implementing these remaining
-  methods remains a task for the future, see **TODO** below. All four methods do
-  support `audit_action=AuditAction.IGNORE` usage, however.
+- At this time, only the `QuerySet.delete()` and `QuerySet.update()` "special"
+  write methods can actually perform change auditing when called with 
+  `audit_action=AuditAction.AUDIT`. The other three methods are currently not
+  implemented and will raise `NotImplementedError` if called with that action.
+  Implementing these remaining methods remains a task for the future, see
+  **TODO** below. All four methods do support `audit_action=AuditAction.IGNORE`
+  usage, however.
 
 #### Bootstrap events for models with existing records
 

--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ twine upload dist/*
 - Implement auditing for the remaining "special" QuerySet write operations:
   - `bulk_create()`
   - `bulk_update()`
-  - `update()`
 - Write full library documentation using github.io.
 - Switch to `pytest` to support Python 3.10.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ details:
   above) will raise an exception when the model class is evaluated.
 - At this time, only the `QuerySet.delete()` and `QuerySet.update()` "special"
   write methods can actually perform change auditing when called with 
-  `audit_action=AuditAction.AUDIT`. The other three methods are currently not
+  `audit_action=AuditAction.AUDIT`. The other two methods are currently not
   implemented and will raise `NotImplementedError` if called with that action.
   Implementing these remaining methods remains a task for the future, see
   **TODO** below. All four methods do support `audit_action=AuditAction.IGNORE`

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ twine upload dist/*
   - `bulk_update()`
 - Write full library documentation using github.io.
 - Switch to `pytest` to support Python 3.10.
+- Wrap audited DB write methods in Django's transaction.atomic context manager
 
 ### Backlog
 

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -334,7 +334,8 @@ class AuditEvent(models.Model):
                 )
             object_pk = instance.pk
         # fetch (and reset for next db write operation) initial values
-        fields_to_audit = init_values.keys() if init_values else cls._field_names(instance)
+        fields_to_audit = init_values.keys() if init_values else \
+            cls._field_names(instance)
         init_values = init_values or cls.reset_initial_values(instance)
         delta = {}
         for field_name in fields_to_audit:
@@ -580,7 +581,9 @@ class AuditingQuerySet(models.QuerySet):
         request = request.get()
 
         fields_to_update = set(kw.keys())
-        audited_fields = set(getattr(self.model, AuditEvent.ATTACH_FIELD_NAMES_AT))
+        audited_fields = set(
+            getattr(self.model, AuditEvent.ATTACH_FIELD_NAMES_AT)
+        )
         fields_to_audit = fields_to_update & audited_fields
         if not fields_to_audit:
             # no audited fields are changing
@@ -598,7 +601,9 @@ class AuditingQuerySet(models.QuerySet):
         audit_events = []
         for instance in self:
             init_values = old_values[instance.pk]
-            audit_event = AuditEvent.make_audit_event(instance, False, False, request, init_values=init_values)
+            audit_event = AuditEvent.make_audit_event(
+                instance, False, False, request, init_values=init_values
+            )
             if audit_event:
                 audit_events.append(audit_event)
         if audit_events:

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -4,7 +4,7 @@ from functools import wraps
 from itertools import islice
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 
 from .const import BOOTSTRAP_BATCH_SIZE
 from .utils import class_import_helper
@@ -593,22 +593,24 @@ class AuditingQuerySet(models.QuerySet):
             pk = value.pop('pk')
             old_values[pk] = value
 
-        rows = super().update(**kw)
-
-        # create and write the audit events _after_ the update succeeds
-        from .field_audit import request
-        request = request.get()
-        audit_events = []
-        for instance in self:
-            init_values = old_values[instance.pk]
-            audit_event = AuditEvent.make_audit_event(
-                instance, False, False, request, init_values=init_values
-            )
-            if audit_event:
-                audit_events.append(audit_event)
-        if audit_events:
-            AuditEvent.objects.bulk_create(audit_events)
-        return rows
+        # open a transaction in db of audited model
+        db = self.first()._state.db
+        with transaction.atomic(using=db):
+            rows = super().update(**kw)
+            # create and write the audit events _after_ the update succeeds
+            from .field_audit import request
+            request = request.get()
+            audit_events = []
+            for instance in self:
+                init_values = old_values[instance.pk]
+                audit_event = AuditEvent.make_audit_event(
+                    instance, False, False, request, init_values=init_values
+                )
+                if audit_event:
+                    audit_events.append(audit_event)
+            if audit_events:
+                AuditEvent.objects.bulk_create(audit_events)
+            return rows
 
 
 AuditingManager = models.Manager.from_queryset(AuditingQuerySet)

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -572,9 +572,9 @@ class AuditingQuerySet(models.QuerySet):
         return value
 
     @validate_audit_action
-    def update(self, *args, audit_action=AuditAction.RAISE, **kw):
+    def update(self, audit_action=AuditAction.RAISE, **kw):
         if audit_action is AuditAction.IGNORE:
-            return super().update(*args, **kw)
+            return super().update(**kw)
         assert audit_action is AuditAction.AUDIT, audit_action
         from .field_audit import request
         request = request.get()

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -4,7 +4,7 @@ from functools import wraps
 from itertools import islice
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import models
 
 from .const import BOOTSTRAP_BATCH_SIZE
 from .utils import class_import_helper
@@ -587,30 +587,28 @@ class AuditingQuerySet(models.QuerySet):
             # no audited fields are changing
             return super().update(**kw)
 
-        # since we fetch objects from this queryset, save old values, update,
-        # and then fetch the objects again, we need to lock until this is done
-        with transaction.atomic():
-            values_to_fetch = fields_to_update | {"pk"}
-            old_values = {}
-            for value in self.values(*values_to_fetch):
-                pk = value.pop('pk')
-                old_values[pk] = value
+        values_to_fetch = fields_to_update | {"pk"}
+        old_values = {}
+        for value in self.values(*values_to_fetch):
+            pk = value.pop('pk')
+            old_values[pk] = value
 
-            rows = super().update(**kw)
-            # create and write the audit events _after_ the update succeeds
-            audit_events = []
-            from .field_audit import request
-            request = request.get()
-            for instance in self:
-                init_values = old_values[instance.pk]
-                audit_event = AuditEvent.make_audit_event(
-                    instance, False, False, request, init_values=init_values
-                )
-                if audit_event:
-                    audit_events.append(audit_event)
-            if audit_events:
-                AuditEvent.objects.bulk_create(audit_events)
-            return rows
+        rows = super().update(**kw)
+
+        # create and write the audit events _after_ the update succeeds
+        from .field_audit import request
+        request = request.get()
+        audit_events = []
+        for instance in self:
+            init_values = old_values[instance.pk]
+            audit_event = AuditEvent.make_audit_event(
+                instance, False, False, request, init_values=init_values
+            )
+            if audit_event:
+                audit_events.append(audit_event)
+        if audit_events:
+            AuditEvent.objects.bulk_create(audit_events)
+        return rows
 
 
 AuditingManager = models.Manager.from_queryset(AuditingQuerySet)

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,6 +26,7 @@ class SimpleModel(Model):
 class ModelWithAuditingManager(Model):
     id = AutoField(primary_key=True)
     value = CharField(max_length=8, null=True)
+    non_audited_field = CharField(max_length=12, null=True)
     objects = AuditingManager()
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -872,12 +872,13 @@ class TestAuditingQuerySet(TestCase):
         queryset = ModelWithAuditingManager.objects.all()
         # if make_audit_event fails for any reason, db changes should roll back
         with patch('field_audit.models.AuditEvent.make_audit_event',
-                   side_effect=Exception()):
+                   side_effect=Exception()) as mocked_make_audit_event:
             try:
                 queryset.update(value='updated', audit_action=AuditAction.AUDIT)
             except Exception:
                 pass
 
+        mocked_make_audit_event.assert_called()
         instance = ModelWithAuditingManager.objects.get(id=0)
         self.assertEqual("initial", instance.value)
         self.assertEqual(0, AuditEvent.objects.filter(object_pk=instance.pk,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -845,6 +845,16 @@ class TestAuditingQuerySet(TestCase):
             queryset.update(**items, audit_action=AuditAction.IGNORE)
             super_meth.assert_called_with(**items)
 
+    def test_update_audit_action_raise_raises_exception(self):
+        queryset = AuditingQuerySet()
+        with self.assertRaises(UnsetAuditActionError):
+            queryset.update(value='updated', audit_action=AuditAction.RAISE)
+
+    def test_update_audit_action_default_raises_exception(self):
+        queryset = AuditingQuerySet()
+        with self.assertRaises(UnsetAuditActionError):
+            queryset.update(value='updated')
+
 
 class TestAuditEventBootstrapping(TestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -794,10 +794,36 @@ class TestAuditingQuerySet(TestCase):
             queryset.delete(audit_action=AuditAction.IGNORE)
             super_meth.assert_called()
 
-    def test_update_audit_action_audit_is_not_implemented(self):
-        queryset = AuditingQuerySet()
-        with self.assertRaises(NotImplementedError):
-            queryset.update([], audit_action=AuditAction.AUDIT)
+    def test_update_audit_action_audit_creates_audit_events(self):
+        for pkey in range(2):
+            ModelWithAuditingManager.objects.create(id=pkey, value="initial")
+
+        queryset = ModelWithAuditingManager.objects.all()
+        queryset.update(value='updated', audit_action=AuditAction.AUDIT)
+
+        instances = ModelWithAuditingManager.objects.all()
+        for instance in instances:
+            self.assertEqual("updated", instance.value)
+            event, = AuditEvent.objects.filter(object_pk=instance.pk, is_create=False, is_delete=False)
+            self.assertEqual(
+                "tests.models.ModelWithAuditingManager",
+                event.object_class_path,
+            )
+            self.assertEqual(
+                {"value": {"old": "initial", "new": "updated"}},
+                event.delta,
+            )
+
+    def test_update_audit_action_audit_does_not_create_audit_events_if_audited_field_stays_the_same(self):
+        ModelWithAuditingManager.objects.create(id=0, value="initial")
+
+        queryset = ModelWithAuditingManager.objects.all()
+        queryset.update(value='initial', audit_action=AuditAction.AUDIT)
+
+        instance, = ModelWithAuditingManager.objects.all()
+        self.assertEqual(
+            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False,is_delete=False).count()
+        )
 
     def test_update_audit_action_ignore_calls_super(self):
         queryset = AuditingQuerySet()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -804,7 +804,8 @@ class TestAuditingQuerySet(TestCase):
         instances = ModelWithAuditingManager.objects.all()
         for instance in instances:
             self.assertEqual("updated", instance.value)
-            event, = AuditEvent.objects.filter(object_pk=instance.pk, is_create=False, is_delete=False)
+            event, = AuditEvent.objects.filter(object_pk=instance.pk,
+                                               is_create=False, is_delete=False)
             self.assertEqual(
                 "tests.models.ModelWithAuditingManager",
                 event.object_class_path,
@@ -814,7 +815,7 @@ class TestAuditingQuerySet(TestCase):
                 event.delta,
             )
 
-    def test_update_audit_action_audit_does_not_create_audit_events_if_audited_field_stays_the_same(self):
+    def test_update_audit_action_audit_does_not_create_audit_events_if_audited_field_stays_the_same(self):  # noqa: E501
         ModelWithAuditingManager.objects.create(id=0, value="initial")
 
         queryset = ModelWithAuditingManager.objects.all()
@@ -822,20 +823,24 @@ class TestAuditingQuerySet(TestCase):
 
         instance, = ModelWithAuditingManager.objects.all()
         self.assertEqual(
-            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False,is_delete=False).count()
+            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False,
+                                         is_delete=False).count()
         )
 
-    def test_update_audit_action_audit_does_not_create_audit_events_if_no_audited_field_updated(self):
+    def test_update_audit_action_audit_does_not_create_audit_events_if_no_audited_field_updated(self):  # noqa: E501
         ModelWithAuditingManager.objects.create(id=0, value="initial")
 
         queryset = ModelWithAuditingManager.objects.all()
-        queryset.update(non_audited_field='updated', audit_action=AuditAction.AUDIT)
+        queryset.update(
+            non_audited_field='updated', audit_action=AuditAction.AUDIT
+        )
 
         instance, = ModelWithAuditingManager.objects.all()
         self.assertEqual(instance.value, 'initial')
         self.assertEqual(instance.non_audited_field, 'updated')
         self.assertEqual(
-            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False, is_delete=False).count()
+            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False,
+                                         is_delete=False).count()
         )
 
     def test_update_audit_action_ignore_does_not_create_audit_events(self):
@@ -847,7 +852,8 @@ class TestAuditingQuerySet(TestCase):
         instance, = ModelWithAuditingManager.objects.all()
         self.assertEqual(instance.value, 'updated')
         self.assertEqual(
-            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False, is_delete=False).count()
+            0, AuditEvent.objects.filter(object_pk=instance.pk, is_create=False,
+                                         is_delete=False).count()
         )
 
     def test_update_audit_action_raise_raises_exception(self):


### PR DESCRIPTION
This tackles the `update()` portion of [this TODO](https://github.com/dimagi/django-field-audit#todo). A lot of this work code likely be reused for the `bulk_update` method as well, but I wanted to keep this PR focused on `update` only.

**Review by commit**

The unique aspect of creating audit events for this update method is that the `AuditEvent.ATTACH_INIT_VALUES_AT` cannot be used because if you fetch the instances prior to the update, the instances contain the old value for `ATTACH_INIT_VALUES_AT`, and if you fetch the instances after the update, they contain the new value for `ATTACH_INIT_VALUES_AT`.

Instead, we need to fetch the current values and save them off manually prior to calling update, and then add support to `make_audit_event` to allow custom values for `init_values` rather than checking `ATTACH_INIT_VALUES_AT`.

In addition to this, I added some tests for the `update` method for the `AuditAction.RAISE` case, as well as the "default" case when no `audit_action` is specified. I also updated the test for `AuditAction.IGNORE` to ensure no audit events are created as expected.