### PR TITLE
Add transactions to audited methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ details:
   Implementing these remaining methods remains a task for the future, see
   **TODO** below. All four methods do support `audit_action=AuditAction.IGNORE`
   usage, however.
+- All audited methods use transactions to ensure changes to audited models
+  are only committed to the database if audit events are successfully created
+  and saved as well.
 
 #### Bootstrap events for models with existing records
 
@@ -253,7 +256,6 @@ twine upload dist/*
   - `bulk_update()`
 - Write full library documentation using github.io.
 - Switch to `pytest` to support Python 3.10.
-- Wrap audited DB write methods in Django's transaction.atomic context manager
 
 ### Backlog
 

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -4,7 +4,7 @@ from functools import wraps
 from itertools import islice
 
 from django.conf import settings
-from django.db import models, router, transaction
+from django.db import models, transaction
 
 from .const import BOOTSTRAP_BATCH_SIZE
 from .utils import class_import_helper
@@ -567,7 +567,7 @@ class AuditingQuerySet(models.QuerySet):
                 instance.pk,
             ))
 
-        with transaction.atomic(using=router.db_for_write(self.model)):
+        with transaction.atomic(using=self.db):
             value = super().delete()
             if audit_events:
                 # write the audit events _after_ the delete succeeds
@@ -595,7 +595,7 @@ class AuditingQuerySet(models.QuerySet):
             pk = value.pop('pk')
             old_values[pk] = value
 
-        with transaction.atomic(using=router.db_for_write(self.model)):
+        with transaction.atomic(using=self.db):
             rows = super().update(**kw)
             # create and write the audit events _after_ the update succeeds
             from .field_audit import request

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,0 +1,2 @@
+class MakeAuditEventException(Exception):
+    """Test specific exception used when mocking make_audit_event"""

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,0 +1,7 @@
+from contextlib import contextmanager
+
+
+class NoopAtomicTransaction:
+    @contextmanager
+    def atomic(self, *args, **kwargs):
+        yield

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -863,8 +863,12 @@ class TestAuditingQuerySet(TestCase):
               self.assertRaises(MakeAuditEventException)):
             queryset.delete(audit_action=AuditAction.AUDIT)
 
-        instance = ModelWithAuditingManager.objects.get(id=0)
-        self.assertIsNotNone(instance)
+        try:
+            ModelWithAuditingManager.objects.get(id=0)
+        except ModelWithAuditingManager.DoesNotExist:
+            self.fail(
+                "Expected object with id=0 to exist, but test failed to roll "
+                "back delete operation on ModelWithAuditingManager queryset.")
 
     def test_delete_audit_action_audit_rolls_back_if_audit_event_save_fails(self):  # noqa: E501
         ModelWithAuditingManager.objects.create(id=0, value="initial")


### PR DESCRIPTION
**Review by commit**

Based on conversations from https://github.com/dimagi/django-field-audit/pull/11, a TODO was added to wrap remaining audited methods in a SQL/Django transaction to enable rolling back DB changes if any errors are encountered. This prevents the potential for a gap in audit logs due to an unexpected failure, and does imply that if writing audit events fail, the write to the audited model will fail as well.