### PR TITLE
Improve special QuerySet write arg validation

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -490,7 +490,14 @@ def validate_audit_action(func):
     :raises: ``InvalidAuditActionError`` or ``UnsetAuditActionError``
     """
     @wraps(func)
-    def wrapper(self, *args, audit_action=AuditAction.RAISE, **kw):
+    def wrapper(self, *args, **kw):
+        try:
+            audit_action = kw["audit_action"]
+        except KeyError:
+            raise UnsetAuditActionError(
+                f"{type(self).__name__}.{func.__name__}() requires an audit "
+                "action as a keyword argument."
+            )
         if audit_action not in AuditAction:
             raise InvalidAuditActionError(
                 "The 'audit_action' argument must be a value of 'AuditAction', "
@@ -501,7 +508,7 @@ def validate_audit_action(func):
                 f"{type(self).__name__}.{func.__name__}() requires an audit "
                 "action"
             )
-        return func(self, *args, audit_action=audit_action, **kw)
+        return func(self, *args, **kw)
     return wrapper
 
 

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -580,7 +580,7 @@ class AuditingQuerySet(models.QuerySet):
         return value
 
     @validate_audit_action
-    def update(self, audit_action=AuditAction.RAISE, **kw):
+    def update(self, *, audit_action=AuditAction.RAISE, **kw):
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)
         assert audit_action is AuditAction.AUDIT, audit_action

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -717,9 +717,22 @@ class TestValidateAuditAction(TestCase):
     def test_validate_audit_action_ignore(self):
         self._func(audit_action=AuditAction.IGNORE)  # does not raise
 
-    def test_validate_audit_action_raises_unsetauditactionerror(self):
-        with self.assertRaises(UnsetAuditActionError):
+    def test_validate_audit_action_raise(self):
+        with self.assertRaises(UnsetAuditActionError) as test:
+            self._func(audit_action=AuditAction.RAISE)
+        self.assertEqual(
+            str(test.exception),
+            "TestValidateAuditAction._func() requires an audit action",
+        ),
+
+    def test_validate_audit_action_requires_keyword_argument(self):
+        with self.assertRaises(UnsetAuditActionError) as test:
             self._func()
+        self.assertEqual(
+            str(test.exception),
+            "TestValidateAuditAction._func() requires an audit action as a "
+            "keyword argument.",
+        ),
 
     def test_validate_audit_action_raises_invalidauditactionerror(self):
         class Action(Enum):


### PR DESCRIPTION
Improve code clarity and fix `update()` method args.

- Improve special QuerySet write method argument validation
- Define `audit_action` as a keyword-only argument for `AuditingQuerySet.update()` (added in #11) to reflect what the validation decorator requires.
