### PR TITLE
Add docstring to AuditingQuerySet.update

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -581,6 +581,12 @@ class AuditingQuerySet(models.QuerySet):
 
     @validate_audit_action
     def update(self, *, audit_action=AuditAction.RAISE, **kw):
+        """
+        In order to determine what the old and new values of instances within
+        the queryset, one additional fetch on this queryset is performed,
+        resulting in two fetches of items in the queryset and one bulk creation
+        of audit events
+        """
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)
         assert audit_action is AuditAction.AUDIT, audit_action


### PR DESCRIPTION
In response to comment on https://github.com/dimagi/django-field-audit/pull/11#discussion_r1031121988

This actually made me think again about why I implemented `AuditingQuerySet.update` the way I did, and I think it was mainly to conform to the current implementation of `make_audit_event` which is silly. We know what the new values will be based on the kwargs passed into `update` so we should only have to do one fetch of the queryset to obtain the existing values. Granted relying on the kwargs passed in and not the _actual_ values set on the instances post-update might not be as robust, but I don't think we have any reason to believe the update would result in anything else. I can add a TODO to the README if others share this view.