### PR TITLE
Create a method to make audit events from values rather than an instance

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -293,13 +293,13 @@ class AuditEvent(models.Model):
 
     @classmethod
     def audit_field_changes(cls, *args, **kw):
-        """Convenience method that calls ``make_audit_event()`` and saves the
-        event (if one is returned).
+        """Convenience method that calls ``make_audit_event_from_instance()``
+        and saves the event (if one is returned).
 
-        All [keyword] arguments are passed directly to ``make_audit_event()``,
-        see that method for usage.
+        All [keyword] arguments are passed directly to
+        ``make_audit_event_from_instance()``, see that method for usage.
         """
-        event = cls.make_audit_event(*args, **kw)
+        event = cls.make_audit_event_from_instance(*args, **kw)
         if event is not None:
             event.save()
 
@@ -364,8 +364,8 @@ class AuditEvent(models.Model):
         return delta
 
     @classmethod
-    def make_audit_event(cls, instance, is_create, is_delete,
-                         request, object_pk=None):
+    def make_audit_event_from_instance(cls, instance, is_create, is_delete,
+                                       request, object_pk=None):
         """Factory method for creating a new ``AuditEvent`` for an instance of a
         model that's being audited for changes.
 
@@ -637,8 +637,8 @@ class AuditingQuerySet(models.QuerySet):
         request = request.get()
         audit_events = []
         for instance in self:
-            # make_audit_event() will never return None because delete=True
-            audit_events.append(AuditEvent.make_audit_event(
+            # make_audit_event_from_instance cannot return None when delete=True
+            audit_events.append(AuditEvent.make_audit_event_from_instance(
                 instance,
                 False,
                 True,

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -404,17 +404,24 @@ class AuditEvent(models.Model):
                                             init_values)
 
         if delta:
-            from .auditors import audit_dispatcher
-            from .field_audit import get_audited_class_path
-            change_context = audit_dispatcher.dispatch(request)
-            return cls(
-                object_class_path=get_audited_class_path(type(instance)),
-                object_pk=object_pk,
-                change_context=cls._change_context_db_value(change_context),
-                is_create=is_create,
-                is_delete=is_delete,
-                delta=delta,
-            )
+            return cls.create_audit_event(object_pk, type(instance), delta,
+                                          is_create, is_delete, request)
+
+    @classmethod
+    def create_audit_event(cls, object_pk, object_cls, delta, is_create,
+                           is_delete, request):
+        from .auditors import audit_dispatcher
+        from .field_audit import get_audited_class_path
+        change_context = audit_dispatcher.dispatch(request)
+        object_cls_path = get_audited_class_path(object_cls)
+        return cls(
+            object_class_path=object_cls_path,
+            object_pk=object_pk,
+            change_context=cls._change_context_db_value(change_context),
+            is_create=is_create,
+            is_delete=is_delete,
+            delta=delta,
+        )
 
     @classmethod
     def bootstrap_existing_model_records(cls, model_class, field_names,
@@ -635,10 +642,10 @@ class AuditingQuerySet(models.QuerySet):
     @validate_audit_action
     def update(self, *, audit_action=AuditAction.RAISE, **kw):
         """
-        In order to determine what the old and new values of instances within
-        the queryset, one additional fetch on this queryset is performed,
-        resulting in two fetches of items in the queryset and one bulk creation
-        of audit events
+        In order to determine the old and new values of instances within
+        the queryset, a fetch of audited values on this queryset is performed,
+        resulting in one fetch of the audited instances, one update of the
+        audited instances, and one bulk creation of audit events.
         """
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)
@@ -653,8 +660,10 @@ class AuditingQuerySet(models.QuerySet):
             # no audited fields are changing
             return super().update(**kw)
 
-        values_to_fetch = fields_to_update | {"pk"}
+        new_values = {field: kw[field] for field in fields_to_audit}
+
         old_values = {}
+        values_to_fetch = fields_to_update | {"pk"}
         for value in self.values(*values_to_fetch):
             pk = value.pop('pk')
             old_values[pk] = value
@@ -665,13 +674,15 @@ class AuditingQuerySet(models.QuerySet):
             from .field_audit import request
             request = request.get()
             audit_events = []
-            for instance in self:
-                init_values = old_values[instance.pk]
-                audit_event = AuditEvent.make_audit_event(
-                    instance, False, False, request, init_values=init_values
-                )
-                if audit_event:
-                    audit_events.append(audit_event)
+
+            for pk, old_values_for_pk in old_values.items():
+                delta = AuditEvent.create_delta(old_values_for_pk, new_values)
+                if delta:
+                    audit_event = AuditEvent.create_audit_event(
+                        pk, self.model, delta, False, False, request
+                    )
+                    if audit_event:
+                        audit_events.append(audit_event)
             if audit_events:
                 AuditEvent.objects.bulk_create(audit_events)
             return rows

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -656,10 +656,10 @@ class AuditingQuerySet(models.QuerySet):
     @validate_audit_action
     def update(self, *, audit_action=AuditAction.RAISE, **kw):
         """
-        In order to determine the old and new values of instances within
-        the queryset, a fetch of audited values on this queryset is performed,
-        resulting in one fetch of the audited instances, one update of the
-        audited instances, and one bulk creation of audit events.
+        In order to determine the old and new values of the records matched by
+        the queryset, a fetch of audited values for the matched records is
+        performed, resulting in one fetch of the current values, one update of
+        the matched records, and one bulk creation of audit events.
         """
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -2,5 +2,5 @@ class MakeAuditEventException(Exception):
     """Test specific exception used when mocking make_audit_event"""
 
 
-class CreateAuditEventException(Exception):
-    """Test specific exception used when mocking create_audit_event"""
+class MakeAuditEventFromValuesException(Exception):
+    """Test specific exception used when mocking make_audit_event_from_values"""

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,2 +1,6 @@
 class MakeAuditEventException(Exception):
     """Test specific exception used when mocking make_audit_event"""
+
+
+class CreateAuditEventException(Exception):
+    """Test specific exception used when mocking create_audit_event"""

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,5 +1,6 @@
-class MakeAuditEventException(Exception):
-    """Test specific exception used when mocking make_audit_event"""
+class MakeAuditEventFromInstanceException(Exception):
+    """Test specific exception used when mocking
+    make_audit_event_from_instance"""
 
 
 class MakeAuditEventFromValuesException(Exception):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -744,6 +744,41 @@ class TestAuditEvent(TestCase):
             )
         self.assertEqual(delta, {'value': {'old': 10, 'new': 2}})
 
+    def test_create_delta_returns_new_when_old_values_is_empty(self):
+        old_values = {}
+        new_values = {'f1': 'initial', 'f2': 0}
+        delta = AuditEvent.create_delta(old_values, new_values)
+        self.assertEqual(delta, {'f1': {'new': 'initial'}, 'f2': {'new': 0}})
+
+    def test_create_delta_returns_old_when_new_values_is_empty(self):
+        old_values = {'f1': 'initial', 'f2': 0}
+        new_values = {}
+        delta = AuditEvent.create_delta(old_values, new_values)
+        self.assertEqual(delta, {'f1': {'old': 'initial'}, 'f2': {'old': 0}})
+
+    def test_create_delta_returns_old_and_new_when_changes(self):
+        old_values = {'f1': 'initial', 'f2': 0}
+        new_values = {'f1': 'updated', 'f2': 0}
+        delta = AuditEvent.create_delta(old_values, new_values)
+        self.assertEqual(delta, {'f1': {'old': 'initial', 'new': 'updated'}})
+
+    def test_create_delta_returns_new_when_old_values_missing_field(self):
+        old_values = {'f1': 'initial'}
+        new_values = {'f1': 'updated', 'f2': 0}
+        delta = AuditEvent.create_delta(old_values, new_values)
+        self.assertEqual(delta, {'f1': {'old': 'initial', 'new': 'updated'},
+                                 'f2': {'new': 0}})
+
+    def test_create_delta_returns_empty_when_no_changes(self):
+        old_values = {'f1': 'initial', 'f2': 0}
+        new_values = {'f1': 'initial', 'f2': 0}
+        delta = AuditEvent.create_delta(old_values, new_values)
+        self.assertFalse(delta)
+
+    def test_create_delta_raises_exception_if_old_and_new_values_are_empty(self):  # noqa: E501
+        with self.assertRaises(AssertionError):
+            AuditEvent.create_delta({}, {})
+
     def test__change_context_db_value_returns_empty_dict_for_none(self):
         self.assertEqual({}, AuditEvent._change_context_db_value(None))
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,7 +27,10 @@ from field_audit.models import (
     get_manager,
     validate_audit_action,
 )
-from .exceptions import MakeAuditEventException
+from .exceptions import (
+    CreateAuditEventException,
+    MakeAuditEventException,
+)
 from .mocks import NoopAtomicTransaction
 
 from .models import (
@@ -1066,9 +1069,9 @@ class TestAuditingQuerySet(TestCase):
         ModelWithAuditingManager.objects.create(id=0, value="initial")
         queryset = ModelWithAuditingManager.objects.all()
 
-        with (patch('field_audit.models.AuditEvent.make_audit_event',
-                    side_effect=MakeAuditEventException()),
-              self.assertRaises(MakeAuditEventException)):
+        with (patch('field_audit.models.AuditEvent.create_audit_event',
+                    side_effect=CreateAuditEventException()),
+              self.assertRaises(CreateAuditEventException)):
             queryset.update(value='updated', audit_action=AuditAction.AUDIT)
 
         instance = ModelWithAuditingManager.objects.get(id=0)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -736,17 +736,6 @@ class TestAuditEvent(TestCase):
               self.assertRaises(AssertionError)):
             AuditEvent.get_delta_from_instance(instance, True, True)
 
-    @audit_field_names(TestModel, ["value"])
-    def test_get_delta_from_instance_overrides_old_value_with_init_values_if_provided(self):  # noqa: E501
-        instance = TestModel(id=1, value=1)
-        AuditEvent.attach_initial_values(instance)
-        instance.value = 2
-        with override_audited_models({TestModel: "TestModel"}):
-            delta = AuditEvent.get_delta_from_instance(
-                instance, False, False, init_values={'value': 10}
-            )
-        self.assertEqual(delta, {'value': {'old': 10, 'new': 2}})
-
     def test_create_delta_returns_new_when_old_values_is_empty(self):
         old_values = {}
         new_values = {'f1': 'initial', 'f2': 0}


### PR DESCRIPTION
See the description and comments in https://github.com/dimagi/django-field-audit/pull/16 for context.

The existing `make_audit_event`'s dependency on the actual updated instance of the audited model requires having two fetches of the queryset in the AuditingQuerySet.update method, which is inefficient. This change is an attempt to create an additional flow to create audit events without the need for an instance of the audited model.

**Review by commit**

Each commit message explains the reasoning behind the changes, and eventually leads to two separate `make_audit_event_from_...` methods that feed into similar logic. This new `make_audit_event_from_values` method can be used in other AuditingQuerySet methods like `delete`, but I wanted to make sure the initial refactor is agreed upon before proceeding.