### PR TITLE
Use `make_audit_event_from_values` in AuditingQuerySet.delete

### DIFF
--- a/field_audit/management/commands/bootstrap_field_audit_events.py
+++ b/field_audit/management/commands/bootstrap_field_audit_events.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
             stream.write(f"done ({count})")
 
     def do_bootstrap(self, model_class, bootstrap_method, **bootstrap_kw):
-        field_names = self.get_field_names(model_class)
+        field_names = AuditEvent.field_names(model_class)
         if not field_names:
             raise CommandError(
                 f"invalid fields ({field_names!r}) for model: {model_class}"
@@ -102,14 +102,6 @@ class Command(BaseCommand):
         "init": init_all,
         "top-up": top_up_missing,
     }
-
-    @staticmethod
-    def get_field_names(model_class):
-        """Extract the field names from a model class.
-
-        TODO: expose a method on the AuditEvent class for doing this.
-        """
-        return AuditEvent._field_names(model_class())
 
     @contextmanager
     def bootstrap_action_log(self, *args, **kw):

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -236,12 +236,12 @@ class AuditEvent(models.Model):
         setattr(model_class, cls.ATTACH_FIELD_NAMES_AT, field_names)
 
     @classmethod
-    def _field_names(cls, instance):
-        """Returns the audit field names stored on the model instance's class
+    def field_names(cls, model_class):
+        """Returns the audit field names stored on the audited Model class
 
-        :param instance: instance of a Model subclass being audited for changes
+        :param model_class: a Django Model class under audit
         """
-        return getattr(instance.__class__, cls.ATTACH_FIELD_NAMES_AT)
+        return getattr(model_class, cls.ATTACH_FIELD_NAMES_AT)
 
     @staticmethod
     def get_field_value(instance, field_name):
@@ -270,7 +270,7 @@ class AuditEvent(models.Model):
                 f"refusing to overwrite {cls.ATTACH_INIT_VALUES_AT!r} "
                 f"on model instance: {instance}"
             )
-        field_names = cls._field_names(instance)
+        field_names = cls.field_names(instance)
         init_values = {f: cls.get_field_value(instance, f) for f in field_names}
         setattr(instance, cls.ATTACH_INIT_VALUES_AT, init_values)
 
@@ -319,7 +319,7 @@ class AuditEvent(models.Model):
         """
         assert not (is_create and is_delete),\
             "is_create and is_delete cannot both be true"
-        fields_to_audit = cls._field_names(instance)
+        fields_to_audit = cls.field_names(instance)
         # fetch (and reset for next db write operation) initial values
         old_values = {} if is_create else cls.reset_initial_values(instance)
         new_values = {} if is_delete else \
@@ -636,10 +636,7 @@ class AuditingQuerySet(models.QuerySet):
         from .field_audit import request
         request = request.get()
         audit_events = []
-        fields_to_fetch = set(
-            getattr(self.model, AuditEvent.ATTACH_FIELD_NAMES_AT)
-        )
-        fields_to_fetch |= {"pk"}
+        fields_to_fetch = set(AuditEvent.field_names(self.model)) | {'pk'}
         current_values = {}
         for values_for_instance in self.values(*fields_to_fetch):
             pk = values_for_instance.pop('pk')
@@ -675,9 +672,7 @@ class AuditingQuerySet(models.QuerySet):
         assert audit_action is AuditAction.AUDIT, audit_action
 
         fields_to_update = set(kw.keys())
-        audited_fields = set(
-            getattr(self.model, AuditEvent.ATTACH_FIELD_NAMES_AT)
-        )
+        audited_fields = set(AuditEvent.field_names(self.model))
         fields_to_audit = fields_to_update & audited_fields
         if not fields_to_audit:
             # no audited fields are changing

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -987,9 +987,9 @@ class TestAuditingQuerySet(TestCase):
         queryset = ModelWithAuditingManager.objects.all()
 
         with (patch(
-                'field_audit.models.AuditEvent.make_audit_event_from_instance',
-                side_effect=MakeAuditEventFromInstanceException()),
-              self.assertRaises(MakeAuditEventFromInstanceException)):
+                'field_audit.models.AuditEvent.make_audit_event_from_values',
+                side_effect=MakeAuditEventFromValuesException()),
+              self.assertRaises(MakeAuditEventFromValuesException)):
             queryset.delete(audit_action=AuditAction.AUDIT)
 
         try:


### PR DESCRIPTION
Now that `make_audit_event_from_values` exists, it makes sense to use this method instead of `make_audit_event_from_instance` to optimize the fetch of instances in the queryset. The optimization is that we only need to fetch the values being audited + the primary key to successfully create audit events.