### PR TITLE
Implement AuditingQuerySet.bulk_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ details:
 - Specifying `audit_special_queryset_writes=True` (step **1** above) without
   setting the default manager to an instance of `AuditingManager` (step **2**
   above) will raise an exception when the model class is evaluated.
-- At this time, only the `QuerySet.delete()` and `QuerySet.update()` "special"
-  write methods can actually perform change auditing when called with 
-  `audit_action=AuditAction.AUDIT`. The other two methods are currently not
-  implemented and will raise `NotImplementedError` if called with that action.
-  Implementing these remaining methods remains a task for the future, see
-  **TODO** below. All four methods do support `audit_action=AuditAction.IGNORE`
-  usage, however.
+- At this time, `QuerySet.delete()`, `QuerySet.update()`,
+  and `QuerySet.bulk_create()` "special" write methods can actually perform
+  change auditing when called with `audit_action=AuditAction.AUDIT`. 
+  `QuerySet.bulk_update()` is not currently implemented and will raise
+  `NotImplementedError` if called with that action. Implementing this remaining
+  method remains a task for the future, see **TODO** below. All four methods do
+  support `audit_action=AuditAction.IGNORE` usage, however.
 - All audited methods use transactions to ensure changes to audited models
   are only committed to the database if audit events are successfully created
   and saved as well.
@@ -252,7 +252,6 @@ twine upload dist/*
 ## TODO
 
 - Implement auditing for the remaining "special" QuerySet write operations:
-  - `bulk_create()`
   - `bulk_update()`
 - Write full library documentation using github.io.
 - Switch to `pytest` to support Python 3.10.

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -611,13 +611,23 @@ class AuditingQuerySet(models.QuerySet):
     """
 
     @validate_audit_action
-    def bulk_create(self, *args, audit_action=AuditAction.RAISE, **kw):
-        if audit_action is AuditAction.IGNORE:
-            return super().bulk_create(*args, **kw)
-        else:
-            raise NotImplementedError(
-                "Change auditing is not implemented for bulk_create()."
-            )
+    def bulk_create(self, objs, audit_action=AuditAction.RAISE, **kw):
+        if audit_action is AuditAction.IGNORE or not objs:
+            return super().bulk_create(objs, **kw)
+        assert audit_action is AuditAction.AUDIT, audit_action
+
+        from .field_audit import request
+        request = request.get()
+
+        with transaction.atomic(using=self.db):
+            created_objs = super().bulk_create(objs, **kw)
+            audit_events = []
+            for obj in created_objs:
+                audit_events.append(
+                    AuditEvent.make_audit_event_from_instance(
+                        obj, True, False, request))
+            AuditEvent.objects.bulk_create(audit_events)
+            return created_objs
 
     @validate_audit_action
     def bulk_update(self, *args, audit_action=AuditAction.RAISE, **kw):

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -611,7 +611,7 @@ class AuditingQuerySet(models.QuerySet):
     """
 
     @validate_audit_action
-    def bulk_create(self, objs, audit_action=AuditAction.RAISE, **kw):
+    def bulk_create(self, objs, *, audit_action=AuditAction.RAISE, **kw):
         if audit_action is AuditAction.IGNORE or not objs:
             return super().bulk_create(objs, **kw)
         assert audit_action is AuditAction.AUDIT, audit_action


### PR DESCRIPTION
Another item on the TODO list, this one turned out to be very straightforward since the `bulk_create` method expects a list of objects to be created.

**Review by commit**
You can basically skip the first commit as it is just a reorganization, and only serves to make this diff harder to read.