### PR TITLE
Support django.db.models.Expression objects in AuditingQuerySet.update

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -5,6 +5,7 @@ from itertools import islice
 
 from django.conf import settings
 from django.db import models, transaction
+from django.db.models import Expression
 
 from .const import BOOTSTRAP_BATCH_SIZE
 from .utils import class_import_helper
@@ -676,6 +677,9 @@ class AuditingQuerySet(models.QuerySet):
         the queryset, a fetch of audited values for the matched records is
         performed, resulting in one fetch of the current values, one update of
         the matched records, and one bulk creation of audit events.
+
+        NOTE: if django.db.models.Expressions are provided as update arguments,
+        an additional fetch of records is performed to obtain new values.
         """
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)
@@ -689,6 +693,8 @@ class AuditingQuerySet(models.QuerySet):
             return super().update(**kw)
 
         new_values = {field: kw[field] for field in fields_to_audit}
+        uses_expressions = any(
+            [isinstance(val, Expression) for val in new_values.values()])
 
         old_values = {}
         values_to_fetch = fields_to_update | {"pk"}
@@ -698,14 +704,23 @@ class AuditingQuerySet(models.QuerySet):
 
         with transaction.atomic(using=self.db):
             rows = super().update(**kw)
+            if uses_expressions:
+                # fetch updated values to ensure audit event deltas are accurate
+                # after update is performed with expressions
+                new_values = {}
+                for value in self.values(*values_to_fetch):
+                    pk = value.pop('pk')
+                    new_values[pk] = value
+            else:
+                new_values = {pk: new_values for pk in old_values.keys()}
+
             # create and write the audit events _after_ the update succeeds
             from .field_audit import request
             request = request.get()
             audit_events = []
-
             for pk, old_values_for_pk in old_values.items():
                 audit_event = AuditEvent.make_audit_event_from_values(
-                    old_values_for_pk, new_values, pk, self.model, request
+                    old_values_for_pk, new_values[pk], pk, self.model, request
                 )
                 if audit_event:
                     audit_events.append(audit_event)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, Mock, patch
 import django
 from django.conf import settings
 from django.db import connection, models, transaction
+from django.db.models import Case, When, Value
 from django.db.utils import IntegrityError, DatabaseError
 from django.test import TestCase, override_settings
 
@@ -1115,6 +1116,34 @@ class TestAuditingQuerySetUpdate(TestCase):
 
         instance = ModelWithAuditingManager.objects.get(id=0)
         self.assertEqual("initial", instance.value)
+
+    def test_update_audit_action_audit_with_expressions_succeeds(self):
+        update_kwargs = {}
+        when_statements = []
+        field = ModelWithAuditingManager._meta.get_field('value')
+        for pkey in range(2):
+            obj = ModelWithAuditingManager.objects.create(id=pkey,
+                                                          value="initial")
+            attr = Value(f'updated-{pkey}', output_field=field)
+            when_statements.append(When(pk=obj.pk, then=attr))
+        case_statement = Case(*when_statements, output_field=field)
+        update_kwargs[field.attname] = case_statement
+
+        queryset = ModelWithAuditingManager.objects.all()
+        queryset.update(**dict(update_kwargs, audit_action=AuditAction.AUDIT))
+
+        instances = ModelWithAuditingManager.objects.all()
+        for instance in instances:
+            self.assertEqual(f"updated-{instance.id}", instance.value)
+            
+            event, = AuditEvent.objects.filter(object_pk=instance.pk,
+                                               is_create=False, is_delete=False)
+            self.assertEqual(
+                "tests.models.ModelWithAuditingManager",
+                event.object_class_path)
+            self.assertEqual(
+                {"value": {"old": "initial", "new": f"updated-{instance.id}"}},
+                event.delta)
 
 
 class TestAuditingQuerySetDelete(TestCase):


### PR DESCRIPTION
After looking into implementing auditing for AuditingQuerySet.bulk_update, it was discovered that `bulk_update` calls into `update` but with kwargs that use django Expression objects. The current implementation of `update` does not support expressions, so these changes were made to support it.

Most notably, in the event that expressions are used, there is an additional fetch performed as part of the `update` now to ensure that the `new_values` are accurate. I figured rather than try to decode the "new value" out of the expression objects, a more robust solution is to just perform the update, and read the new values off of the objects, with the trade off being less performant.