### PR TITLE
Run test on latest 4.2.x commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
         experimental: [false]
         include:
         - python: '3.9'
-          django: 'https://github.com/django/django/archive/refs/heads/main.zip#egg=Django'
+          django: 'https://github.com/django/django/archive/refs/heads/stable/4.2.x.zip#egg=Django'
           experimental: true
           # NOTE this job will appear to pass even when it fails because of
           # `continue-on-error: true`. Github Actions apparently does not


### PR DESCRIPTION
The main branch of the django repo now contains code that does not support python 3.9. To continue to test the latest commits that support 3.9, I'm replacing the test on django's main branch with a test on django's 4.2.x branch.