### PR TITLE
Resolve issues with initial values

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -321,7 +321,9 @@ class AuditEvent(models.Model):
             "is_create and is_delete cannot both be true"
         fields_to_audit = cls.field_names(instance)
         # fetch (and reset for next db write operation) initial values
-        old_values = {} if is_create else cls.reset_initial_values(instance)
+        # NOTE: even if is_create is True, we need to call reset_initial_values
+        init_values = cls.reset_initial_values(instance)
+        old_values = {} if is_create else init_values
         new_values = {} if is_delete else \
             {f: cls.get_field_value(instance, f) for f in fields_to_audit}
         return cls.create_delta(old_values, new_values)

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -308,6 +308,8 @@ class AuditEvent(models.Model):
         """
         Returns a dictionary representing the delta of an instance of a model
         being audited for changes.
+        Has the side effect of calling cls.reset_initial_values(instance)
+        which grabs and updates the initial values stored on the instance.
 
         :param instance: instance of a Model subclass to be audited for changes
         :param is_create: whether or not the audited event creates a new DB
@@ -320,8 +322,7 @@ class AuditEvent(models.Model):
         assert not (is_create and is_delete),\
             "is_create and is_delete cannot both be true"
         fields_to_audit = cls.field_names(instance)
-        # fetch (and reset for next db write operation) initial values
-        # NOTE: even if is_create is True, we need to call reset_initial_values
+        # SIDE EFFECT: fetch and reset initial values for next db write
         init_values = cls.reset_initial_values(instance)
         old_values = {} if is_create else init_values
         new_values = {} if is_delete else \

--- a/tests/models.py
+++ b/tests/models.py
@@ -30,13 +30,14 @@ class ModelWithAuditingManager(Model):
     objects = AuditingManager()
 
 
-@audit_fields("id", "value_on_save")
+@audit_fields("id", "save_count")
 class ModelWithValueOnSave(Model):
     id = AutoField(primary_key=True)
-    value_on_save = CharField(max_length=16, null=True)
+    value = CharField(max_length=16, null=True)
+    save_count = IntegerField(default=0)
 
     def save(self, *args, **kwargs):
-        self.value_on_save = 'override'
+        self.save_count += 1
         super().save(*args, **kwargs)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -30,6 +30,16 @@ class ModelWithAuditingManager(Model):
     objects = AuditingManager()
 
 
+@audit_fields("id", "value_on_save")
+class ModelWithValueOnSave(Model):
+    id = AutoField(primary_key=True)
+    value_on_save = CharField(max_length=16, null=True)
+
+    def save(self, *args, **kwargs):
+        self.value_on_save = 'override'
+        super().save(*args, **kwargs)
+
+
 @audit_fields("name", "title", "flight_hours")
 class CrewMember(Model):
     id = AutoField(primary_key=True)

--- a/tests/test_django_compat.py
+++ b/tests/test_django_compat.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 
 from field_audit.models import AuditEvent
 
-from .models import SimpleModel
+from .models import ModelWithValueOnSave, SimpleModel
 
 
 class TestAuditedDbWrites(TestCase):
@@ -16,6 +16,16 @@ class TestAuditedDbWrites(TestCase):
         self.assertAuditEvent(
             is_delete=True,
             delta={"id": {"old": instance.id}, "value": {"old": None}},
+        )
+
+    def test_model_delete_with_value_on_save_is_audited(self):
+        self.assertNoAuditEvents()
+        instance = ModelWithValueOnSave.objects.create(id=0)
+        AuditEvent.objects.all().delete()  # delete the create audit event
+        instance.delete()
+        self.assertAuditEvent(
+            is_delete=True,
+            delta={'id': {'old': 0}, 'value_on_save': {'old': 'override'}},
         )
 
     def test_model_save_is_audited(self):

--- a/tests/test_django_compat.py
+++ b/tests/test_django_compat.py
@@ -10,12 +10,12 @@ class TestAuditedDbWrites(TestCase):
 
     def test_model_delete_is_audited(self):
         self.assertNoAuditEvents()
-        instance = SimpleModel.objects.create()
+        instance = SimpleModel.objects.create(id=0, value='test')
         AuditEvent.objects.all().delete()  # delete the create audit event
         instance.delete()
         self.assertAuditEvent(
             is_delete=True,
-            delta={"id": {"old": instance.id}, "value": {"old": None}},
+            delta={"id": {"old": 0}, "value": {"old": 'test'}},
         )
 
     def test_model_delete_with_value_on_save_is_audited(self):

--- a/tests/test_field_audit.py
+++ b/tests/test_field_audit.py
@@ -25,6 +25,7 @@ from .models import (
     Flight,
     SimpleModel,
     ModelWithAuditingManager,
+    ModelWithValueOnSave,
     PkAuto,
     PkJson,
 )
@@ -125,6 +126,7 @@ class TestFieldAudit(TestCase):
                 Flight,
                 SimpleModel,
                 ModelWithAuditingManager,
+                ModelWithValueOnSave,
                 PkAuto,
                 PkJson,
             },


### PR DESCRIPTION
Some issues with initial values have been uncovered, initially thanks to a failing test in https://github.com/dimagi/commcare-hq/pull/32663.

#### Modifying attributes in the `save` method

The failing test pointed to an issue when auditing a model that overrides the implementation of `save`, specifically to modify an audited attribute. The key is when this modification happens, as there are two key steps that happen when calling `save` on an audited model:

1) An audit event is created. `django-field-audit` wraps the `save` call on an audited model [to create an audit event](https://github.com/dimagi/django-field-audit/blob/8ff9ad1be979d378739753521b473e36f13a8393/field_audit/field_audit.py#L123-L129), which notably is the first thing that happens after calling `save`. 

2) `super().save(...)` is called, committing the changes to the database for the instance of the audited model. 

In this case, the modification of an audited attribute happened in between these two steps. This caused an issue because as part of creating an audit event, the initial values on the instance should be updated. Due to [a bug](https://github.com/dimagi/django-field-audit/blob/4d51eaa1f6004d747f663307341cb044a09f4762/field_audit/models.py#L324) introduced in v1.2.5, the initial values were not updated when creating a new object. This meant that if a subsequent database write method was called on the instance, like `delete`, the initial values were inaccurate. This issue was resolved in d272585fe05ef33a99bded14e3745b2b45ce77c7.

#### A faulty test

Once this issue was resolved, the `TestAuditedDbWrites.test_model_delete_is_audited` test started to fail. This test asserted using `instance.id`, but at this point in the test, `instance` was deleted and therefore `instance.id` was equivalent to `None`. Given that the instance was saved and the `id` was set properly, the audit event delta should have included the value for `id`, not `None`. To resolve this, I explicitly set the `id` field when creating the object, and assert against that value.

Its success in versions <1.2.5 was due to fetching the value to be used in the delta for the delete audit event from the instance post deletion. See https://github.com/dimagi/django-field-audit/blob/2206aeea2b71f51e1422ff5656e928a577cd8d8a/field_audit/models.py#L342

Its success in version 1.2.5 was due to not setting init values properly when creating a new instance of an audited model, which meant the init values used when creating an audit event for the deletion of the instance weren't correct. See https://github.com/dimagi/django-field-audit/blob/4d51eaa1f6004d747f663307341cb044a09f4762/field_audit/models.py#L324