### PR TITLE
Release v1.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Django Field Audit change log
 
+## v1.2.6 - 2023-03-03
+- Resolve bug with incorrect previous values when updating an audited field in
+  the save method of the object.
+
 ## v1.2.5 - 2023-02-22
 - All audited methods use SQL transactions to ensure changes to audited models
   are only written to the database if the audit event is successfully written

--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,3 +1,3 @@
 from .field_audit import audit_fields  # noqa: F401
 
-__version__ = "1.2.5"
+__version__ = "1.2.6"


### PR DESCRIPTION
This release resolves a bug where previous values in an audit event `delta` may be incorrect if the audited field is updated in the `save` method.

This release includes the following PRs:
- https://github.com/dimagi/django-field-audit/pull/25