### PR TITLE
Support django expressions in AuditingQuerySet.update

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -25,7 +25,7 @@ class SimpleModel(Model):
 @audit_fields("id", "value", audit_special_queryset_writes=True)
 class ModelWithAuditingManager(Model):
     id = AutoField(primary_key=True)
-    value = CharField(max_length=8, null=True)
+    value = CharField(max_length=16, null=True)
     non_audited_field = CharField(max_length=12, null=True)
     objects = AuditingManager()
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1135,7 +1135,6 @@ class TestAuditingQuerySetUpdate(TestCase):
         instances = ModelWithAuditingManager.objects.all()
         for instance in instances:
             self.assertEqual(f"updated-{instance.id}", instance.value)
-            
             event, = AuditEvent.objects.filter(object_pk=instance.pk,
                                                is_create=False, is_delete=False)
             self.assertEqual(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, Mock, patch
 import django
 from django.conf import settings
 from django.db import connection, models, transaction
+from django.db.models import Case, When, Value
 from django.db.utils import IntegrityError, DatabaseError
 from django.test import TestCase, override_settings
 
@@ -1115,6 +1116,34 @@ class TestAuditingQuerySetUpdate(TestCase):
 
         instance = ModelWithAuditingManager.objects.get(id=0)
         self.assertEqual("initial", instance.value)
+
+    def test_update_audit_action_audit_with_expressions_succeeds(self):
+        update_kwargs = {}
+        when_statements = []
+        field = ModelWithAuditingManager._meta.get_field('value')
+        for pkey in range(2):
+            obj = ModelWithAuditingManager.objects.create(id=pkey,
+                                                          value="initial")
+            attr = Value(f'updated-{pkey}', output_field=field)
+            when_statements.append(When(pk=obj.pk, then=attr))
+        case_statement = Case(*when_statements, output_field=field)
+        update_kwargs[field.attname] = case_statement
+
+        queryset = ModelWithAuditingManager.objects.all()
+        queryset.update(**dict(update_kwargs, audit_action=AuditAction.AUDIT))
+
+        instances = ModelWithAuditingManager.objects.all()
+        for instance in instances:
+            self.assertEqual(f"updated-{instance.id}", instance.value)
+            
+            event, = AuditEvent.objects.filter(object_pk=instance.pk,
+                                               is_create=False, is_delete=False)
+            self.assertEqual(
+                "tests.models.ModelWithAuditingManager",
+                event.object_class_path)
+            self.assertEqual(
+                {"value": {"old": "initial", "new": f"updated-{instance.id}"}},
+                event.delta)
 
 
 class TestAuditingQuerySetDelete(TestCase):


### PR DESCRIPTION
Re-creating a closed PR from January. Closing it was not the right approach as I really just wanted to de-prioritize it, but ended up forgetting about it.

> After looking into implementing auditing for AuditingQuerySet.bulk_update, it was discovered that `bulk_update` calls into `update` but with kwargs that use django Expression objects. The current implementation of `update` does not support expressions, so these changes were made to support it.
>
> Most notably, in the event that expressions are used, there is an additional fetch performed as part of the `update` now to ensure that the new_values are accurate. I figured rather than try to decode the "new value" out of the expression objects, a more robust solution is to just perform the update, and read the new values off of the objects, with the trade off being less performant.

https://github.com/dimagi/django-field-audit/pull/20