### PR TITLE
Switch from nose to pynose

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,8 +20,9 @@ jobs:
         pip install django pynose coverage
     - name: Run coverage
       run: |
+        coverage run -m nose
         # .coverage.* files are ignored by git
-        pynose --with-coverage --cover-erase --cover-package=field_audit | tee .coverage.out
+        coverage report -m | tee .coverage.out
         percent=$(grep -E '^TOTAL\s.+\s[0-9]{1,3}%$' .coverage.out \
                   | awk '{gsub("%$", "", $NF); print($NF)}')
         python scripts/make-coverage-badge.py -o .coverage.svg "$percent"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,12 +17,11 @@ jobs:
       run: |
         python --version
         pip install --upgrade pip wheel
-        pip install django nose coverage
+        pip install django pynose coverage
     - name: Run coverage
       run: |
-        coverage run -m nose
         # .coverage.* files are ignored by git
-        coverage report -m | tee .coverage.out
+        pynose --with-coverage --cover-erase --cover-package=field_audit | tee .coverage.out
         percent=$(grep -E '^TOTAL\s.+\s[0-9]{1,3}%$' .coverage.out \
                   | awk '{gsub("%$", "", $NF); print($NF)}')
         python scripts/make-coverage-badge.py -o .coverage.svg "$percent"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: switch to pytest to support 3.10 (nosetests is broken on 3.10)
         python: ['3.9']
         django:
         - 'Django>=3.2,<3.3'
@@ -48,7 +47,7 @@ jobs:
       run: |
         python --version
         pip install --upgrade pip wheel
-        pip install "${{ matrix.django }}" psycopg2-binary nose flake8 coverage
+        pip install "${{ matrix.django }}" psycopg2-binary pynose flake8 coverage
     - name: Run tests
       env:
         DB_SETTINGS: >-
@@ -60,7 +59,7 @@ jobs:
             "HOST":"localhost",
             "PORT":"5432"
           }
-      run: nosetests -v --with-coverage --cover-branches --cover-package=field_audit
+      run: pynose -v --with-coverage --cover-branches --cover-package=field_audit
       continue-on-error: ${{ matrix.experimental }}
     - name: Check migrations
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,7 +59,7 @@ jobs:
             "HOST":"localhost",
             "PORT":"5432"
           }
-      run: pynose -v --with-coverage --cover-branches --cover-package=field_audit
+      run: nosetests -v --with-coverage --cover-branches --cover-package=field_audit
       continue-on-error: ${{ matrix.experimental }}
     - name: Check migrations
       run: |

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ your local Python's `sqlite3` library ships with the `JSON1` extension enabled
 
 - Tests
   ```shell
-  nosetests 
+  nosetests
   ```
 
 - Style check

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ your local Python's `sqlite3` library ships with the `JSON1` extension enabled
 
 - Tests
   ```shell
-  pynose 
+  nosetests 
   ```
 
 - Style check

--- a/README.md
+++ b/README.md
@@ -231,7 +231,8 @@ your local Python's `sqlite3` library ships with the `JSON1` extension enabled
 
 - Coverage
   ```shell
-  pynose --with-coverage --cover-erase --cover-package field_audit
+  coverage run -m nose
+  coverage report -m
   ```
 
 ### Adding migrations

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ Create/activate a python virtualenv and install the required dependencies.
 ```shell
 cd django-field-audit
 mkvirtualenv django-field-audit  # or however you choose to setup your environment
-pip install django nose flake8 coverage
+pip install django pynose flake8 coverage
 ```
 
 ### Running tests
@@ -221,7 +221,7 @@ your local Python's `sqlite3` library ships with the `JSON1` extension enabled
 
 - Tests
   ```shell
-  nosetests
+  pynose 
   ```
 
 - Style check
@@ -231,8 +231,7 @@ your local Python's `sqlite3` library ships with the `JSON1` extension enabled
 
 - Coverage
   ```shell
-  coverage run -m nose
-  coverage report -m
+  pynose --with-coverage --cover-erase --cover-package field_audit
   ```
 
 ### Adding migrations

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -320,7 +320,7 @@ class AuditEvent(models.Model):
         :returns: {field_name: {'old': old_value, 'new': new_value}, ...}
         :raises: ``AssertionError`` if both is_create and is_delete are true
         """
-        assert not (is_create and is_delete),\
+        assert not (is_create and is_delete), \
             "is_create and is_delete cannot both be true"
         fields_to_audit = cls.field_names(instance)
         # SIDE EFFECT: fetch and reset initial values for next db write


### PR DESCRIPTION
[pynose](https://pypi.org/project/pynose/) is an updated version of nose, with support for newer versions of python. The lack of support for newer versions of python was initially a reason to switch test frameworks, but pynose enables retaining the most compatibility with the current test framework while also enabling usage of newer python versions.