### PR TITLE
use django timezone util to avoid runtime warnings

### DIFF
--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum
 from functools import wraps
 from itertools import islice

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -6,6 +6,7 @@ from itertools import islice
 from django.conf import settings
 from django.db import models, transaction
 from django.db.models import Expression
+from django.utils import timezone
 
 from .const import BOOTSTRAP_BATCH_SIZE
 from .utils import class_import_helper
@@ -197,7 +198,7 @@ def get_date():
     This is the "getter" for default values of the ``AuditEvent.event_date``
     field.
     """
-    return datetime.utcnow()
+    return timezone.now()
 
 
 class AuditEvent(models.Model):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,5 +1,5 @@
 from contextlib import ContextDecorator
-from datetime import datetime, timedelta
+from datetime import timedelta
 from enum import Enum
 from unittest.mock import ANY, Mock, patch
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,6 +10,7 @@ from django.db import connection, models, transaction
 from django.db.models import Case, When, Value
 from django.db.utils import IntegrityError, DatabaseError
 from django.test import TestCase, override_settings
+from django.utils import timezone
 
 from field_audit.auditors import audit_dispatcher
 from field_audit.const import BOOTSTRAP_BATCH_SIZE
@@ -295,7 +296,7 @@ class TestGetFuncs(TestCase):
     def test_get_date(self):
         then = get_date()
         self.assertLess(
-            datetime.utcnow() - then,
+            timezone.now() - then,
             timedelta(seconds=1),
         )
 


### PR DESCRIPTION
Depending on the Django settings the DateTimeField expects either a naive or non-naive datetime object. A runtime warning is emitted if the field receives a value it is not expecting.

Using `django.utils.timezone.now` solves this since it returns the datetime with the correct TZ value.

Warning message for reference:

```
 .../django/db/models/fields/__init__.py:1595: RuntimeWarning: DateTimeField AuditEvent.event_date received a naive datetime (2024-01-24 09:28:14.565753) while time zone support is active.
```