### PR TITLE
Don't fail when 'who' binary is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Django Field Audit change log
 
+## v1.2.9 - 2025-02-21
+- Don't fail when attempting to use the `who` command to get the current user if the `who` command is not available e.g. on Windows.
+
 ## v1.2.8 - 2024-01-24
 - Use Django's `timezone.now` instead of `datetime.now` to ensure the correct
   timezone is used when creating audit events.

--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,3 +1,3 @@
 from .field_audit import audit_fields  # noqa: F401
 
-__version__ = "1.2.8"
+__version__ = "1.2.9"

--- a/field_audit/auditors.py
+++ b/field_audit/auditors.py
@@ -107,7 +107,7 @@ class SystemUserAuditor(BaseAuditor):
             try:
                 # get owner of STDIN file on login sessions (e.g. SSH)
                 output = check_output(["who", "-m"], stderr=DEVNULL)
-            except CalledProcessError:
+            except (FileNotFoundError, CalledProcessError):
                 self.has_who_bin = False
             else:
                 if output:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,6 @@ license_file = LICENSE
 
 [flake8]
 max-line-length = 80
-exclude = ./build
+exclude =
+    ./build
+    .venv

--- a/tests/test_auditors.py
+++ b/tests/test_auditors.py
@@ -165,9 +165,22 @@ class TestSystemUserAuditor(TestCase):
         chk_out.assert_called_once()
         getuser.assert_called_once()
 
-    def test_systemuserauditor_remembers_missing_who_bin(self):
+    def test_systemuserauditor_remembers_who_error(self):
         def fail(*args, **kw):
             raise CalledProcessError(1, [], "")
+        ch_by = {"user_type": USER_TYPE_PROCESS, "username": "carlos"}
+        # round 1
+        chk_out, getuser = self._patch_system_getters_and_validate(fail, ch_by)
+        chk_out.assert_called_once()
+        getuser.assert_called_once()
+        # round 2
+        chk_out, getuser = self._patch_system_getters_and_validate(fail, ch_by)
+        chk_out.assert_not_called()
+        getuser.assert_called_once()
+
+    def test_systemuserauditor_remembers_missing_missing_who_bin(self):
+        def fail(*args, **kw):
+            raise FileNotFoundError()
         ch_by = {"user_type": USER_TYPE_PROCESS, "username": "carlos"}
         # round 1
         chk_out, getuser = self._patch_system_getters_and_validate(fail, ch_by)

--- a/tests/test_auditors.py
+++ b/tests/test_auditors.py
@@ -178,17 +178,12 @@ class TestSystemUserAuditor(TestCase):
         chk_out.assert_not_called()
         getuser.assert_called_once()
 
-    def test_systemuserauditor_remembers_missing_missing_who_bin(self):
+    def test_systemuserauditor_handles_missing_who_bin(self):
         def fail(*args, **kw):
             raise FileNotFoundError()
         ch_by = {"user_type": USER_TYPE_PROCESS, "username": "carlos"}
-        # round 1
         chk_out, getuser = self._patch_system_getters_and_validate(fail, ch_by)
         chk_out.assert_called_once()
-        getuser.assert_called_once()
-        # round 2
-        chk_out, getuser = self._patch_system_getters_and_validate(fail, ch_by)
-        chk_out.assert_not_called()
         getuser.assert_called_once()
 
     def test_systemuserauditor_change_context_returns_tty_user_on_who_output(self):  # noqa: E501


### PR DESCRIPTION
`subprocess.check_output` raises a `FileNotFoundError` if the executable is not present (or can't be found). This is different from the `CalledProcessError` which is raised if the process exits with a non-zero return code.

