### PR TITLE
Add Global Auditing Disable Feature

### DIFF
--- a/field_audit/__init__.py
+++ b/field_audit/__init__.py
@@ -1,4 +1,4 @@
-from .field_audit import audit_fields  # noqa: F401
+from .field_audit import audit_fields, disable_audit, enable_audit  # noqa: F401
 from .services import AuditService, get_audit_service  # noqa: F401
 
 __version__ = "1.4.0"

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -186,6 +186,10 @@ def _decorate_db_write(func):
     """
     @wraps(func)
     def wrapper(self, *args, **kw):
+        # Skip auditing if globally disabled
+        if not is_audit_enabled():
+            return func(self, *args, **kw)
+
         # for details on using 'self._state', see:
         # - https://docs.djangoproject.com/en/dev/ref/models/instances/#state
         # - https://stackoverflow.com/questions/907695/
@@ -258,6 +262,10 @@ def _m2m_changed_handler(sender, instance, action, pk_set, **kwargs):
     :param action: A string indicating the type of update
     :param pk_set: For add/remove actions, set of primary key values
     """
+    # Skip auditing if globally disabled
+    if not is_audit_enabled():
+        return
+
     from .services import get_audit_service
 
     service = get_audit_service()

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -1,11 +1,10 @@
 import contextvars
-from contextlib import contextmanager
 from functools import wraps
 
-from django.conf import settings
 from django.db import models, router, transaction
 from django.db.models.signals import m2m_changed
 
+from .global_context import disable_audit, enable_audit, is_audit_enabled
 from .utils import get_fqcn
 
 __all__ = [
@@ -17,61 +16,6 @@ __all__ = [
     "get_audited_models",
     "request",
 ]
-
-
-# Context variable for enabling/disabling auditing at runtime
-audit_enabled = contextvars.ContextVar("audit_enabled", default=None)
-
-
-def is_audit_enabled():
-    """
-    Check if auditing is currently enabled.
-
-    Returns True if auditing should proceed, False if disabled.
-    Checks context variable first, then falls back to Django setting.
-    """
-    # Check context variable first (runtime override)
-    ctx_value = audit_enabled.get()
-    if ctx_value is not None:
-        return ctx_value
-
-    # Fall back to Django setting (default: True)
-    return getattr(settings, 'FIELD_AUDIT_ENABLED', True)
-
-
-@contextmanager
-def disable_audit():
-    """
-    Context manager to temporarily disable auditing.
-
-    Example:
-        from field_audit import disable_audit
-
-        with disable_audit():
-            # Auditing is disabled in this block
-            obj.save()
-            MyModel.objects.bulk_create(objects)
-    """
-    token = audit_enabled.set(False)
-    try:
-        yield
-    finally:
-        audit_enabled.reset(token)
-
-
-@contextmanager
-def enable_audit():
-    """
-    Context manager to explicitly enable auditing.
-
-    Useful when FIELD_AUDIT_ENABLED=False but you need auditing
-    for a specific block of code.
-    """
-    token = audit_enabled.set(True)
-    try:
-        yield
-    finally:
-        audit_enabled.reset(token)
 
 
 class AlreadyAudited(Exception):

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -9,10 +9,79 @@ from .utils import get_fqcn
 __all__ = [
     "AlreadyAudited",
     "audit_fields",
+    "disable_audit",
+    "enable_audit",
     "get_audited_class_path",
     "get_audited_models",
     "request",
 ]
+
+
+# Context variable for enabling/disabling auditing at runtime
+audit_enabled = contextvars.ContextVar("audit_enabled", default=None)
+
+
+def is_audit_enabled():
+    """
+    Check if auditing is currently enabled.
+
+    Returns True if auditing should proceed, False if disabled.
+    Checks context variable first, then falls back to Django setting.
+    """
+    from django.conf import settings
+
+    # Check context variable first (runtime override)
+    ctx_value = audit_enabled.get()
+    if ctx_value is not None:
+        return ctx_value
+
+    # Fall back to Django setting (default: True)
+    return getattr(settings, 'FIELD_AUDIT_ENABLED', True)
+
+
+def disable_audit():
+    """
+    Context manager to temporarily disable auditing.
+
+    Example:
+        from field_audit import disable_audit
+
+        with disable_audit():
+            # Auditing is disabled in this block
+            obj.save()
+            MyModel.objects.bulk_create(objects)
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _context():
+        token = audit_enabled.set(False)
+        try:
+            yield
+        finally:
+            audit_enabled.reset(token)
+
+    return _context()
+
+
+def enable_audit():
+    """
+    Context manager to explicitly enable auditing.
+
+    Useful when FIELD_AUDIT_ENABLED=False but you need auditing
+    for a specific block of code.
+    """
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _context():
+        token = audit_enabled.set(True)
+        try:
+            yield
+        finally:
+            audit_enabled.reset(token)
+
+    return _context()
 
 
 class AlreadyAudited(Exception):

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -39,6 +39,7 @@ def is_audit_enabled():
     return getattr(settings, 'FIELD_AUDIT_ENABLED', True)
 
 
+@contextmanager
 def disable_audit():
     """
     Context manager to temporarily disable auditing.
@@ -51,17 +52,14 @@ def disable_audit():
             obj.save()
             MyModel.objects.bulk_create(objects)
     """
-    @contextmanager
-    def _context():
-        token = audit_enabled.set(False)
-        try:
-            yield
-        finally:
-            audit_enabled.reset(token)
-
-    return _context()
+    token = audit_enabled.set(False)
+    try:
+        yield
+    finally:
+        audit_enabled.reset(token)
 
 
+@contextmanager
 def enable_audit():
     """
     Context manager to explicitly enable auditing.
@@ -69,15 +67,11 @@ def enable_audit():
     Useful when FIELD_AUDIT_ENABLED=False but you need auditing
     for a specific block of code.
     """
-    @contextmanager
-    def _context():
-        token = audit_enabled.set(True)
-        try:
-            yield
-        finally:
-            audit_enabled.reset(token)
-
-    return _context()
+    token = audit_enabled.set(True)
+    try:
+        yield
+    finally:
+        audit_enabled.reset(token)
 
 
 class AlreadyAudited(Exception):

--- a/field_audit/field_audit.py
+++ b/field_audit/field_audit.py
@@ -1,6 +1,8 @@
 import contextvars
+from contextlib import contextmanager
 from functools import wraps
 
+from django.conf import settings
 from django.db import models, router, transaction
 from django.db.models.signals import m2m_changed
 
@@ -28,8 +30,6 @@ def is_audit_enabled():
     Returns True if auditing should proceed, False if disabled.
     Checks context variable first, then falls back to Django setting.
     """
-    from django.conf import settings
-
     # Check context variable first (runtime override)
     ctx_value = audit_enabled.get()
     if ctx_value is not None:
@@ -51,8 +51,6 @@ def disable_audit():
             obj.save()
             MyModel.objects.bulk_create(objects)
     """
-    from contextlib import contextmanager
-
     @contextmanager
     def _context():
         token = audit_enabled.set(False)
@@ -71,8 +69,6 @@ def enable_audit():
     Useful when FIELD_AUDIT_ENABLED=False but you need auditing
     for a specific block of code.
     """
-    from contextlib import contextmanager
-
     @contextmanager
     def _context():
         token = audit_enabled.set(True)

--- a/field_audit/global_context.py
+++ b/field_audit/global_context.py
@@ -1,0 +1,58 @@
+import contextvars
+from contextlib import contextmanager
+
+from django.conf import settings
+
+# Context variable for enabling/disabling auditing at runtime
+audit_enabled = contextvars.ContextVar("audit_enabled", default=None)
+
+
+def is_audit_enabled():
+    """
+    Check if auditing is currently enabled.
+
+    Returns True if auditing should proceed, False if disabled.
+    Checks context variable first, then falls back to Django setting.
+    """
+    # Check context variable first (runtime override)
+    ctx_value = audit_enabled.get()
+    if ctx_value is not None:
+        return ctx_value
+
+    # Fall back to Django setting (default: True)
+    return getattr(settings, "FIELD_AUDIT_ENABLED", True)
+
+
+@contextmanager
+def disable_audit():
+    """
+    Context manager to temporarily disable auditing.
+
+    Example:
+        from field_audit import disable_audit
+
+        with disable_audit():
+            # Auditing is disabled in this block
+            obj.save()
+            MyModel.objects.bulk_create(objects)
+    """
+    token = audit_enabled.set(False)
+    try:
+        yield
+    finally:
+        audit_enabled.reset(token)
+
+
+@contextmanager
+def enable_audit():
+    """
+    Context manager to explicitly enable auditing.
+
+    Useful when FIELD_AUDIT_ENABLED=False but you need auditing
+    for a specific block of code.
+    """
+    token = audit_enabled.set(True)
+    try:
+        yield
+    finally:
+        audit_enabled.reset(token)

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -703,7 +703,10 @@ class AuditingQuerySet(models.QuerySet):
             return super().bulk_create(objs, **kw)
         assert audit_action is AuditAction.AUDIT, audit_action
 
-        from .field_audit import request
+        from .field_audit import is_audit_enabled, request
+        if not is_audit_enabled():
+            return super().bulk_create(objs, **kw)
+
         request = request.get()
 
         with transaction.atomic(using=self.db):
@@ -732,6 +735,11 @@ class AuditingQuerySet(models.QuerySet):
         if audit_action is AuditAction.IGNORE:
             return super().delete()
         assert audit_action is AuditAction.AUDIT, audit_action
+
+        from .field_audit import is_audit_enabled
+        if not is_audit_enabled():
+            return super().delete()
+
         from .field_audit import request
         from .services import get_audit_service
         service = get_audit_service()
@@ -774,6 +782,10 @@ class AuditingQuerySet(models.QuerySet):
         if audit_action is AuditAction.IGNORE:
             return super().update(**kw)
         assert audit_action is AuditAction.AUDIT, audit_action
+
+        from .field_audit import is_audit_enabled
+        if not is_audit_enabled():
+            return super().update(**kw)
 
         from .services import get_audit_service
         service = get_audit_service()

--- a/field_audit/models.py
+++ b/field_audit/models.py
@@ -684,12 +684,9 @@ class AuditingQuerySet(models.QuerySet):
 
     @validate_audit_action
     def bulk_create(self, objs, *, audit_action=AuditAction.RAISE, **kw):
-        if audit_action is AuditAction.IGNORE or not objs:
+        if audit_action is AuditAction.IGNORE or not is_audit_enabled() or not objs:
             return super().bulk_create(objs, **kw)
         assert audit_action is AuditAction.AUDIT, audit_action
-
-        if not is_audit_enabled():
-            return super().bulk_create(objs, **kw)
 
         current_request = request.get()
 
@@ -715,12 +712,9 @@ class AuditingQuerySet(models.QuerySet):
 
     @validate_audit_action
     def delete(self, *, audit_action=AuditAction.RAISE):
-        if audit_action is AuditAction.IGNORE:
+        if audit_action is AuditAction.IGNORE or not is_audit_enabled():
             return super().delete()
         assert audit_action is AuditAction.AUDIT, audit_action
-
-        if not is_audit_enabled():
-            return super().delete()
 
         service = get_audit_service()
         current_request = request.get()
@@ -759,12 +753,9 @@ class AuditingQuerySet(models.QuerySet):
         NOTE: if django.db.models.Expressions are provided as update arguments,
         an additional fetch of records is performed to obtain new values.
         """
-        if audit_action is AuditAction.IGNORE:
+        if audit_action is AuditAction.IGNORE or not is_audit_enabled():
             return super().update(**kw)
         assert audit_action is AuditAction.AUDIT, audit_action
-
-        if not is_audit_enabled():
-            return super().update(**kw)
 
         service = get_audit_service()
         fields_to_update = set(kw.keys())

--- a/field_audit/services.py
+++ b/field_audit/services.py
@@ -127,6 +127,10 @@ class AuditService:
         All [keyword] arguments are passed directly to
         ``make_audit_event_from_instance()``, see that method for usage.
         """
+        from .field_audit import is_audit_enabled
+        if not is_audit_enabled():
+            return
+
         event = self.make_audit_event_from_instance(*args, **kw)
         if event is not None:
             event.save()
@@ -249,6 +253,10 @@ class AuditService:
 
     def create_audit_event(self, object_pk, object_cls, delta, is_create,
                            is_delete, request):
+        from .field_audit import is_audit_enabled
+        if not is_audit_enabled():
+            return None
+
         from .auditors import audit_dispatcher
         from .field_audit import get_audited_class_path
         from .models import AuditEvent

--- a/field_audit/services.py
+++ b/field_audit/services.py
@@ -3,6 +3,7 @@ from itertools import islice
 from django.db import models
 
 from .const import BOOTSTRAP_BATCH_SIZE
+from .global_context import is_audit_enabled
 
 
 class AuditService:
@@ -127,7 +128,6 @@ class AuditService:
         All [keyword] arguments are passed directly to
         ``make_audit_event_from_instance()``, see that method for usage.
         """
-        from .field_audit import is_audit_enabled
         if not is_audit_enabled():
             return
 
@@ -253,7 +253,6 @@ class AuditService:
 
     def create_audit_event(self, object_pk, object_cls, delta, is_create,
                            is_delete, request):
-        from .field_audit import is_audit_enabled
         if not is_audit_enabled():
             return None
 

--- a/tests/test_global_disable.py
+++ b/tests/test_global_disable.py
@@ -2,7 +2,7 @@
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from field_audit import disable_audit, enable_audit
-from field_audit.field_audit import is_audit_enabled
+from field_audit.field_audit import audit_enabled, is_audit_enabled
 from field_audit.models import AuditEvent, AuditAction
 from tests.models import (
     SimpleModel,
@@ -18,6 +18,8 @@ class SettingsDisableTestCase(TestCase):
     @override_settings(FIELD_AUDIT_ENABLED=False)
     def test_save_disabled_via_setting(self):
         """Verify no audit events created when setting is False."""
+        assert audit_enabled.get() is None
+
         obj = SimpleModel.objects.create(value="test")
         obj.value = "updated"
         obj.save()
@@ -28,6 +30,8 @@ class SettingsDisableTestCase(TestCase):
     @override_settings(FIELD_AUDIT_ENABLED=False)
     def test_delete_disabled_via_setting(self):
         """Verify no audit events on delete when disabled."""
+        assert audit_enabled.get() is None
+
         obj = SimpleModel.objects.create(value="test")
         obj.delete()
 

--- a/tests/test_global_disable.py
+++ b/tests/test_global_disable.py
@@ -32,14 +32,6 @@ class SettingsDisableTestCase(TestCase):
 
         self.assertEqual(AuditEvent.objects.count(), 0)
 
-    def test_save_enabled_by_default(self):
-        """Verify auditing works when setting not specified."""
-        SimpleModel.objects.create(value="test")
-
-        # One create event should exist
-        self.assertEqual(AuditEvent.objects.count(), 1)
-        event = AuditEvent.objects.first()
-        self.assertTrue(event.is_create)
 
 
 class ContextDisableTestCase(TestCase):

--- a/tests/test_global_disable.py
+++ b/tests/test_global_disable.py
@@ -1,0 +1,276 @@
+"""Tests for global auditing disable feature."""
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from django.test import TestCase, override_settings
+
+from field_audit import disable_audit, enable_audit
+from field_audit.models import AuditEvent, AuditAction
+from tests.models import (
+    BasicAuditedModel,
+    M2MAuditedModel,
+    RelatedModel,
+    SpecialQSAuditedModel,
+)
+
+
+class SettingsDisableTestCase(TestCase):
+    """Test FIELD_AUDIT_ENABLED setting."""
+
+    @override_settings(FIELD_AUDIT_ENABLED=False)
+    def test_save_disabled_via_setting(self):
+        """Verify no audit events created when setting is False."""
+        obj = BasicAuditedModel.objects.create(field1="test")
+        obj.field1 = "updated"
+        obj.save()
+
+        # No audit events should be created
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    @override_settings(FIELD_AUDIT_ENABLED=False)
+    def test_delete_disabled_via_setting(self):
+        """Verify no audit events on delete when disabled."""
+        obj = BasicAuditedModel.objects.create(field1="test")
+        pk = obj.pk
+        obj.delete()
+
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_save_enabled_by_default(self):
+        """Verify auditing works when setting not specified."""
+        obj = BasicAuditedModel.objects.create(field1="test")
+
+        # One create event should exist
+        self.assertEqual(AuditEvent.objects.count(), 1)
+        event = AuditEvent.objects.first()
+        self.assertTrue(event.is_create)
+
+
+class ContextDisableTestCase(TestCase):
+    """Test disable_audit() context manager."""
+
+    def test_disable_audit_context_manager(self):
+        """Verify auditing disabled within context."""
+        # Create with auditing (should create event)
+        obj = BasicAuditedModel.objects.create(field1="test")
+        self.assertEqual(AuditEvent.objects.count(), 1)
+
+        # Update with auditing disabled
+        with disable_audit():
+            obj.field1 = "updated"
+            obj.save()
+
+        # Still only one event (create)
+        self.assertEqual(AuditEvent.objects.count(), 1)
+
+    def test_disable_audit_restores_after_exception(self):
+        """Verify auditing re-enabled after exception in context."""
+        try:
+            with disable_audit():
+                obj = BasicAuditedModel.objects.create(field1="test")
+                raise ValueError("test exception")
+        except ValueError:
+            pass
+
+        # Auditing should be re-enabled
+        obj2 = BasicAuditedModel.objects.create(field1="test2")
+        self.assertEqual(AuditEvent.objects.count(), 1)
+
+    def test_nested_disable_contexts(self):
+        """Verify nested disable contexts work correctly."""
+        with disable_audit():
+            obj1 = BasicAuditedModel.objects.create(field1="test1")
+
+            with disable_audit():
+                obj2 = BasicAuditedModel.objects.create(field1="test2")
+
+            obj3 = BasicAuditedModel.objects.create(field1="test3")
+
+        # No events should be created
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+
+class ContextEnableTestCase(TestCase):
+    """Test enable_audit() context manager."""
+
+    @override_settings(FIELD_AUDIT_ENABLED=False)
+    def test_enable_audit_overrides_setting(self):
+        """Verify enable_audit() works when setting is False."""
+        # Create without auditing (setting is False)
+        obj1 = BasicAuditedModel.objects.create(field1="test1")
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+        # Enable for specific operation
+        with enable_audit():
+            obj2 = BasicAuditedModel.objects.create(field1="test2")
+
+        # One event should be created
+        self.assertEqual(AuditEvent.objects.count(), 1)
+        event = AuditEvent.objects.first()
+        self.assertEqual(event.object_pk, str(obj2.pk))
+
+
+class M2MDisableTestCase(TestCase):
+    """Test auditing disable for M2M fields."""
+
+    def test_m2m_disabled_via_context(self):
+        """Verify M2M changes not audited when disabled."""
+        obj = M2MAuditedModel.objects.create(field1="test")
+        related = RelatedModel.objects.create(name="related")
+
+        with disable_audit():
+            obj.m2m_field.add(related)
+
+        # Only create event for main object, no M2M event
+        self.assertEqual(AuditEvent.objects.count(), 1)
+
+    @override_settings(FIELD_AUDIT_ENABLED=False)
+    def test_m2m_disabled_via_setting(self):
+        """Verify M2M changes not audited when setting is False."""
+        obj = M2MAuditedModel.objects.create(field1="test")
+        related = RelatedModel.objects.create(name="related")
+        obj.m2m_field.add(related)
+
+        # No audit events
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+
+class QuerySetDisableTestCase(TestCase):
+    """Test auditing disable for QuerySet operations."""
+
+    def test_bulk_create_disabled(self):
+        """Verify bulk_create respects global disable."""
+        objs = [
+            SpecialQSAuditedModel(field1=f"test{i}")
+            for i in range(5)
+        ]
+
+        with disable_audit():
+            SpecialQSAuditedModel.objects.bulk_create(
+                objs,
+                audit_action=AuditAction.AUDIT
+            )
+
+        # No audit events created
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_queryset_update_disabled(self):
+        """Verify QuerySet.update respects global disable."""
+        objs = [
+            SpecialQSAuditedModel.objects.create(field1=f"test{i}")
+            for i in range(3)
+        ]
+        AuditEvent.objects.all().delete()  # Clear create events
+
+        with disable_audit():
+            SpecialQSAuditedModel.objects.filter(
+                pk__in=[o.pk for o in objs]
+            ).update(field1="updated", audit_action=AuditAction.AUDIT)
+
+        # No audit events for update
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+    def test_queryset_delete_disabled(self):
+        """Verify QuerySet.delete respects global disable."""
+        objs = [
+            SpecialQSAuditedModel.objects.create(field1=f"test{i}")
+            for i in range(3)
+        ]
+        AuditEvent.objects.all().delete()
+
+        with disable_audit():
+            SpecialQSAuditedModel.objects.all().delete(
+                audit_action=AuditAction.AUDIT
+            )
+
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+
+class ThreadSafetyTestCase(TestCase):
+    """Test thread safety of global disable."""
+
+    def test_disable_is_thread_local(self):
+        """Verify disable in one thread doesn't affect others."""
+        results = {"thread1_count": 0, "thread2_count": 0}
+
+        def thread1_work():
+            with disable_audit():
+                BasicAuditedModel.objects.create(field1="thread1")
+            results["thread1_count"] = AuditEvent.objects.filter(
+                object_class_path__contains="BasicAuditedModel"
+            ).count()
+
+        def thread2_work():
+            # No disable - should create audit event
+            BasicAuditedModel.objects.create(field1="thread2")
+            results["thread2_count"] = AuditEvent.objects.filter(
+                object_class_path__contains="BasicAuditedModel"
+            ).count()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            f1 = executor.submit(thread1_work)
+            f2 = executor.submit(thread2_work)
+            f1.result()
+            f2.result()
+
+        # Total should be 1 (only thread2 created event)
+        total = AuditEvent.objects.count()
+        self.assertEqual(total, 1)
+
+
+class BackwardsCompatibilityTestCase(TestCase):
+    """Verify existing behavior unchanged when feature not used."""
+
+    def test_default_behavior_unchanged(self):
+        """Verify auditing still works by default."""
+        # Should work exactly as before
+        obj = BasicAuditedModel.objects.create(field1="test")
+        self.assertEqual(AuditEvent.objects.count(), 1)
+
+        obj.field1 = "updated"
+        obj.save()
+        self.assertEqual(AuditEvent.objects.count(), 2)
+
+        obj.delete()
+        self.assertEqual(AuditEvent.objects.count(), 3)
+
+    def test_audit_action_still_works(self):
+        """Verify AuditAction.IGNORE still works independently."""
+        objs = [
+            SpecialQSAuditedModel(field1=f"test{i}")
+            for i in range(3)
+        ]
+
+        # AuditAction.IGNORE should still work
+        SpecialQSAuditedModel.objects.bulk_create(
+            objs,
+            audit_action=AuditAction.IGNORE
+        )
+
+        self.assertEqual(AuditEvent.objects.count(), 0)
+
+
+class MigrationScenarioTestCase(TestCase):
+    """Test realistic data migration scenario."""
+
+    def test_data_migration_workflow(self):
+        """Simulate data migration without audit overhead."""
+        # Setup: create initial data with auditing
+        initial_objs = [
+            BasicAuditedModel.objects.create(field1=f"initial{i}")
+            for i in range(10)
+        ]
+        initial_event_count = AuditEvent.objects.count()
+        self.assertEqual(initial_event_count, 10)
+
+        # Migration: bulk update without auditing
+        with disable_audit():
+            BasicAuditedModel.objects.all().update(field1="migrated")
+
+        # No additional events created
+        self.assertEqual(AuditEvent.objects.count(), initial_event_count)
+
+        # Verify data actually migrated
+        self.assertTrue(
+            all(obj.field1 == "migrated"
+                for obj in BasicAuditedModel.objects.all())
+        )

--- a/tests/test_global_disable.py
+++ b/tests/test_global_disable.py
@@ -180,39 +180,3 @@ class QuerySetDisableTestCase(TestCase):
             )
 
         self.assertEqual(AuditEvent.objects.count(), 0)
-
-
-class BackwardsCompatibilityTestCase(TestCase):
-    """Verify existing behavior unchanged when feature not used."""
-
-    def test_default_behavior_unchanged(self):
-        """Verify auditing still works by default."""
-        # Should work exactly as before
-        initial_count = AuditEvent.objects.count()
-
-        obj = SimpleModel.objects.create(value="test")
-        self.assertEqual(AuditEvent.objects.count(), initial_count + 1)
-
-        obj.value = "updated"
-        obj.save()
-        self.assertEqual(AuditEvent.objects.count(), initial_count + 2)
-
-        obj.delete()
-        self.assertEqual(AuditEvent.objects.count(), initial_count + 3)
-
-    def test_audit_action_still_works(self):
-        """Verify AuditAction.IGNORE still works independently."""
-        initial_count = AuditEvent.objects.count()
-        objs = [
-            ModelWithAuditingManager(value=f"test{i}")
-            for i in range(3)
-        ]
-
-        # AuditAction.IGNORE should still work
-        ModelWithAuditingManager.objects.bulk_create(
-            objs,
-            audit_action=AuditAction.IGNORE
-        )
-
-        # No new audit events should be created
-        self.assertEqual(AuditEvent.objects.count(), initial_count)

--- a/tests/test_global_disable.py
+++ b/tests/test_global_disable.py
@@ -2,7 +2,7 @@
 from django.test import SimpleTestCase, TestCase, override_settings
 
 from field_audit import disable_audit, enable_audit
-from field_audit.field_audit import audit_enabled, is_audit_enabled
+from field_audit.global_context import audit_enabled, is_audit_enabled
 from field_audit.models import AuditEvent, AuditAction
 from tests.models import (
     SimpleModel,


### PR DESCRIPTION
> [!NOTE]
> This code was originally written by Claude AI
 
## Summary

Adds the ability to globally disable auditing in django-field-audit, providing both application-wide control via Django settings and fine-grained runtime control via context managers. This feature is particularly useful for unit tests, data migrations, bulk imports, and maintenance operations where audit overhead is not needed.

## Implementation

### Core Infrastructure

- **Context Variable**: Uses Python's `contextvars` for thread-safe, async-safe state management
- **Check Function**: `is_audit_enabled()` checks context variable first, then falls back to Django setting
- **Context Managers**: `disable_audit()` and `enable_audit()` for runtime control

### API

New public API exports:
```python
from field_audit import disable_audit, enable_audit
```

New Django setting:
```python
FIELD_AUDIT_ENABLED = False  # Default: True
```

## Usage Examples

### Global Disable via Setting

```python
# settings.py
FIELD_AUDIT_ENABLED = False
```

### Runtime Disable

```python
from field_audit import disable_audit

# Temporarily disable auditing
with disable_audit():
    obj.save()  # No audit event created
    MyModel.objects.bulk_create(objects)  # No audit events
```

### Override Global Setting

```python
from field_audit import enable_audit

# When FIELD_AUDIT_ENABLED=False, temporarily enable
with enable_audit():
    obj.save()  # Audit event IS created
```

### Use Cases

**Unit Tests** - Improve performance by skipping audit overhead:
```python
def test_without_audit(self):
    with disable_audit():
        obj = MyModel.objects.create(field="test")
```

**Data Migrations** - Skip auditing during bulk operations:
```python
def migrate_data():
    with disable_audit():
        MyModel.objects.filter(old=True).update(new=True)
```

### Backwards Compatibility

The new features added in this PR are opt-in and do not break backward compatibility.